### PR TITLE
Handle MapiNotFoundException

### DIFF
--- a/mnamer/__main__.py
+++ b/mnamer/__main__.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 
 from teletype.exceptions import TeletypeQuitException, TeletypeSkipException
+from mapi.exceptions import MapiNotFoundException
 
 from mnamer import VERSION
 from mnamer.args import Arguments
@@ -13,6 +14,7 @@ from mnamer.cli import (
     get_choice,
     msg,
     print_listing,
+    print_heading,
 )
 from mnamer.config import Configuration
 from mnamer.exceptions import MnamerConfigException
@@ -57,6 +59,7 @@ def main():
         if config.get("verbose"):
             print_listing(target.metadata)
         try:
+            print_heading(target)
             get_choice(target)
             msg("moving to %s" % target.destination.full, bullet=True)
             if not config.get("test"):
@@ -69,6 +72,8 @@ def main():
         except TeletypeSkipException:
             msg("SKIPPING as per user request\n", "yellow", True)
             continue
+        except MapiNotFoundException:
+            msg("No matches found, SKIPPING\n", "yellow", True)
 
     # Display results
     summary = "%d out of %d files processed successfully"

--- a/mnamer/cli.py
+++ b/mnamer/cli.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 from teletype.components import SelectOne
 from teletype.components.config import set_style
-from teletype.io import style_format
+from teletype.io import style_format, style_print
 
 try:
     from collections.abc import Mapping, Sequence
@@ -51,11 +51,14 @@ def print_listing(listing, header=None, debug=False):
     print()
 
 
-def get_choice(target):
+def print_heading(target):
     media = target.metadata["media"].title()
     filename = target.source.filename
-    heading = style_format('Processing %s "%s"' % (media, filename), "bold")
+    style_print('Processing %s "%s"' % (media, filename), style="bold")
+
+
+def get_choice(target):
     choices = target.query()
-    choice = SelectOne(choices, heading, skip=True, quit=True).prompt()
+    choice = SelectOne(choices, skip=True, quit=True).prompt()
     target.metadata.update(choice)
     return target.metadata


### PR DESCRIPTION
Allows mnamer to gracefully handle media files that can't be matched to an API provider by catching `MapiNotFoundException`.

closes #22