### PR TITLE
Case insensitive extension mask

### DIFF
--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -57,7 +57,6 @@ class Target:
         file_paths = filter_extensions(file_paths, settings.mask)
         targets = [cls(file_path, settings) for file_path in file_paths]
         targets = list(dict.fromkeys(targets))  # unique values
-        targets = list(filter(cls._matches_mask, targets))
         targets = list(filter(cls._matches_media, targets))
         return targets
 

--- a/mnamer/utils.py
+++ b/mnamer/utils.py
@@ -145,11 +145,11 @@ def filter_extensions(
     file_paths: List[Path], valid_extensions: List[str]
 ) -> List[Path]:
     """Filters (set intersection) a collection of extensions."""
+    valid_extensions = normalize_extensions(valid_extensions)
     return [
         file_path
         for file_path in file_paths
-        if not valid_extensions
-        or file_path.suffix in normalize_extensions(valid_extensions)
+        if not valid_extensions or file_path.suffix.lower() in valid_extensions
     ]
 
 


### PR DESCRIPTION
# Purpose

mnamer's extension mask is currently case sensitive so by default it will skip over any uppercase files. As-is a user could include uppercase extensions by adding them to the mask configuration but given its unlikely anyone would want to exclude uppercase extensions it seems easier to just make the filter case insensitive.

# See Also

- Fixes #41 