### PR TITLE
Add no-replace setting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,41 +4,42 @@
 
 mnamer attempts to load _preferences_ from a **.mnamer-v2.json** file in the home directory, the current working directory, and then in each directory up the drive towards the drive root.
 
-| Preference | Arguments | Description |
-| :--- | :--- | :--- |
-| -b, --batch |  | batch mode; disable interactive prompts |
-| -l, --lower |  | rename files using lowercase characters only |
-| -r, --recurse |  | search for files in nested directories |
-| -s, --scene |  | scene mode; replace non ascii-alphanumerics with `.` |
-| -v, --verbose |  | increase output verbosity |
-| --hits | number | limit the maximum number of hits for each query |
-| --ignore | pattern | ignore files including these words \(regex\) |
-| --mask | extension\(s\) | only process files with given extensions |
-| --nocache |  | disable and clear result cache |
-| --noguess |  | disable best guess fallback; e.g. when no matches, network down |
-| --nostyle |  | disable colours and uses ASCII characters for prompts |
-| --movie-api | **`tmdb`** or `omdb` | set movie api provider |
-| --movie-directory | path | set movie relocation directory |
-| --movie-format | format | set movie renaming format |
-| --episode-api | **`tvmaze`** or `tvdb` | set episode api provider |
-| --episode-directory | path | set episode relocation directory |
-| --episode-format | format | set episode renaming format |
+| Preference          | Arguments              | Description                                                     |
+| :------------------ | :--------------------- | :-------------------------------------------------------------- |
+| -b, --batch         |                        | batch mode; disable interactive prompts                         |
+| -l, --lower         |                        | rename files using lowercase characters only                    |
+| -r, --recurse       |                        | search for files in nested directories                          |
+| -s, --scene         |                        | scene mode; replace non ascii-alphanumerics with `.`            |
+| -v, --verbose       |                        | increase output verbosity                                       |
+| --hits              | number                 | limit the maximum number of hits for each query                 |
+| --ignore            | pattern                | ignore files including these words \(regex\)                    |
+| --mask              | extension\(s\)         | only process files with given extensions                        |
+| --nocache           |                        | disable and clear result cache                                  |
+| --noguess           |                        | disable best guess fallback; e.g. when no matches, network down |
+| --noreplace         |                        | prevent relocation if it would overwrite a file                 |
+| --nostyle           |                        | disable colours and uses ASCII characters for prompts           |
+| --movie-api         | **`tmdb`** or `omdb`   | set movie api provider                                          |
+| --movie-directory   | path                   | set movie relocation directory                                  |
+| --movie-format      | format                 | set movie renaming format                                       |
+| --episode-api       | **`tvmaze`** or `tvdb` | set episode api provider                                        |
+| --episode-directory | path                   | set episode relocation directory                                |
+| --episode-format    | format                 | set episode renaming format                                     |
 
 ## Directives
 
 Whereas preferences configure how mnamer works, _directives_ are one-off parameters that are used to perform secondary tasks like exporting the current option set to a file.
 
-| Directive | Arguments | Description |
-| :--- | :--- | :--- |
-| -V, --version |  | display the running mnamer version number |
-| --config-dump |  | prints config JSON to stdout then exits |
-| --config-ignore |  | skips loading config file for session |
-| --id-imdb | id | specify an IMDb movie id override |
-| --id-tmdb | id | specify a TMDb movie id override |
-| --id-tvdb | id | specify a TVDb series id override |
-| --id-tvmaze | id | specify a TvMaze series id override |
-| --media | `movie` or `episode` | override media detection |
-| --test |  | mocks the renaming and moving of files |
+| Directive       | Arguments            | Description                               |
+| :-------------- | :------------------- | :---------------------------------------- |
+| -V, --version   |                      | display the running mnamer version number |
+| --config-dump   |                      | prints config JSON to stdout then exits   |
+| --config-ignore |                      | skips loading config file for session     |
+| --id-imdb       | id                   | specify an IMDb movie id override         |
+| --id-tmdb       | id                   | specify a TMDb movie id override          |
+| --id-tvdb       | id                   | specify a TVDb series id override         |
+| --id-tvmaze     | id                   | specify a TvMaze series id override       |
+| --media         | `movie` or `episode` | override media detection                  |
+| --test          |                      | mocks the renaming and moving of files    |
 
 ### Saving Preferences
 
@@ -62,11 +63,8 @@ Take care not to write to a location that mnamer reads from because the stream w
 When using `--id` to specify a movie or series id you can can use the following sources for each provider:
 
 | Provider | Accepted IDs |
-| :--- | :--- |
-| OMDb | IMDb |
-| TMDb | TMDb, IMDb |
-| TVDb | TVDb, IMDb |
-| TVMaze | TVMaze, TVDb |
-
-
-
+| :------- | :----------- |
+| OMDb     | IMDb         |
+| TMDb     | TMDb, IMDb   |
+| TVDb     | TVDb, IMDb   |
+| TVMaze   | TVMaze, TVDb |

--- a/mnamer/__main__.py
+++ b/mnamer/__main__.py
@@ -112,7 +112,7 @@ def run():
         except MnamerNetworkException:
             tty.msg("network Error", MessageType.ALERT)
         if not matches and settings.no_guess:
-            tty.msg("skipping (noguess)", MessageType.ALERT)
+            tty.msg("skipping (--noguess)", MessageType.ALERT)
             continue
         try:
             if settings.batch:
@@ -123,24 +123,29 @@ def run():
                 tty.msg("results")
                 match = tty.prompt(matches)
         except (MnamerSkipException, KeyboardInterrupt):
-            tty.msg("skipping as per user request", MessageType.ALERT)
+            tty.msg("skipping (user request)", MessageType.ALERT)
             continue
         except MnamerAbortException:
-            tty.msg("aborting as per user request", MessageType.ERROR)
+            tty.msg("aborting (user request)", MessageType.ERROR)
             break
-
-        # update metadata
         target.metadata.update(match)
+
+        # sanity check move
         if target.destination == target.source:
             tty.msg(
-                f"source and destination paths are the same, nothing to do",
+                f"skipping (source and destination paths are the same)",
                 MessageType.ALERT,
             )
-        else:
+            continue
+        if settings.no_replace and target.destination.exists():
             tty.msg(
-                f"moving to {target.destination.absolute()}",
-                MessageType.SUCCESS,
+                f"skipping (--noreplace)", MessageType.ALERT,
             )
+            continue
+
+        tty.msg(
+            f"moving to {target.destination.absolute()}", MessageType.SUCCESS,
+        )
 
         # rename and move file
         if settings.test:

--- a/mnamer/settings.py
+++ b/mnamer/settings.py
@@ -123,6 +123,16 @@ class Settings:
             help="--noguess: disable best guess; e.g. when no matches or network down",
         )(),
     )
+    no_replace: bool = dataclasses.field(
+        default=False,
+        metadata=ArgSpec(
+            action="store_true",
+            dest="no_replace",
+            flags=["--noreplace", "--no_replace", "--no-replace"],
+            group=SettingsType.PARAMETER,
+            help="--noreplace: prevent relocation if it would overwrite a file",
+        )(),
+    )
     no_style: bool = dataclasses.field(
         default=False,
         metadata=ArgSpec(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -37,6 +37,7 @@ DEFAULT_SETTINGS = {
     "movie_format": "{name} ({year}){extension}",
     "no_cache": False,
     "no_guess": False,
+    "no_replace": False,
     "no_style": False,
     "recurse": False,
     "replacements": {"&": "and", ":": "", ";": ",", "@": "at"},

--- a/tests/e2e/test_moving.py
+++ b/tests/e2e/test_moving.py
@@ -14,14 +14,22 @@ def test_complex_metadata(e2e_run: Callable):
 def test_batch(e2e_run: Callable):
     result = e2e_run("--batch", ".")
     assert result.code == 0
-    assert "12 out of 12 files processed successfully" in result.out
+    assert "11 out of 12 files processed successfully" in result.out
 
 
-def test_batch__noguess(e2e_run: Callable):
+def test_noguess(e2e_run: Callable):
     result = e2e_run("--noguess", "--batch", ".")
     assert result.code == 0
-    assert result.out.count("skipping (noguess)") == 3
+    assert result.out.count("skipping (--noguess)") == 3
     assert "9 out of 12 files processed successfully" in result.out
+
+
+def test_noreplace(e2e_run: Callable):
+    open("Aladdin (1992).avi", "w").close()
+    result = e2e_run("--noreplace", "--batch", "aladdin.1992.avi")
+    assert result.code == 0
+    assert result.out.count("skipping (--noreplace)") == 1
+    assert "0 out of 1 files processed successfully" in result.out
 
 
 def test_ignore(e2e_run: Callable):
@@ -38,7 +46,7 @@ def test_mask(e2e_run: Callable):
     assert ".mkv" not in result.out
     assert ".avi" not in result.out
     assert ".mp4" in result.out
-    assert "7 out of 7 files processed successfully" in result.out
+    assert "6 out of 7 files processed successfully" in result.out
 
 
 def test_multi_part_episode(e2e_run: Callable):


### PR DESCRIPTION
# Purpose

The `--noreplace` flag can be used to prevent accidentally overwriting media files. When applied mnamer will skip over a file if the destination already exists. This is handy when used in conjunction to `--batch` to err on the side of caution.