### PR TITLE
ID Templating Support

### DIFF
--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -33,6 +33,17 @@ In all cases whitespace and punctuation are trimmed and collapsed. Also worth no
 | date    | episode's airdate                                     | Episode    |
 | quality | a combination of parsed audio-visual quality metadata | Any        |
 
+| Field     | Provider |
+| :-------- | :------- |
+| id_imdb   | OMDb     |
+| id_tmdb   | TMDb     |
+| id_tvmaze | TvMaze   |
+| id_tvdb   | TVDb     |
+
+{% hint style="info" %}
+Use the `movie-api` and `episode-api` settings to swtich providers.
+{% endhint %}
+
 ## Examples
 
 ### 00x00 Television Format

--- a/mnamer/metadata.py
+++ b/mnamer/metadata.py
@@ -105,7 +105,7 @@ class Metadata:
     def _format_repl(self, mobj):
         format_string, key = mobj.groups()
         value = _MetaFormatter().vformat(format_string, None, self.as_dict)
-        if key not in {"quality", "group", "extension"}:
+        if key in {"name", "series", "synopsis", "title"}:
             value = str_title_case(value)
         return value
 

--- a/tests/e2e/test_moving.py
+++ b/tests/e2e/test_moving.py
@@ -74,3 +74,25 @@ def test_multiple_nested_directories(e2e_run: Callable):
     )
     assert result.code == 0
     assert "/1/2/3/Teenage Mutant Ninja Turtles (1990).mkv" in result.out
+
+
+def test_format_id__imdb(e2e_run: Callable):
+    result = e2e_run(
+        "--batch",
+        "--movie-api=omdb",
+        "--movie-format='{name} ({id_imdb}).{extension}'",
+        "aladdin.1992.avi",
+    )
+    assert result.code == 0
+    assert "Aladdin (tt0103639).avi" in result.out
+
+
+def test_format_id__tvdb(e2e_run: Callable):
+    result = e2e_run(
+        "--batch",
+        "--episode-api=tvdb",
+        "--episode-format='{id_tvdb}.{season}x{episode}.{extension}'",
+        "archer.2009.s10e07.webrip.x264-lucidtv.mp4",
+    )
+    assert result.code == 0
+    assert "110381.10x7" in result.out


### PR DESCRIPTION
# Purpose

Adds support and documentation for templating db provider ids. Please note that db providers only support their own ids, e.g.:
- TVDb can use `id_tvdb`
- TMDb can use `id_tmdb`
- OMDb can use `id_omdb`
- TvMaze can use `id_tvmaze`

# Example

- **Command**: `mnamer --movie-api=omdb --movie-format="{name} ({id_imdb}).{extension}" demo/aladdin.2019.avi`
- **Result**: `Aladdin (tt6139732).avi`

# See Also
- closes #50 