### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM python:alpine
 ARG MNAMER_VERSION=2.4.2
 ARG UID=1000
 ARG GID=1000
-RUN adduser mnamer --disabled-password
+RUN addgroup mnamer -g $GID
+RUN adduser mnamer -u $UID -G mnamer --disabled-password
 USER mnamer
 RUN pip3 install --no-cache-dir --upgrade pip mnamer==${MNAMER_VERSION}
 ENTRYPOINT ["python", "-m", "mnamer"]


### PR DESCRIPTION
Allow to have GID different from UID while passing buil-arg
Example: --build-arg UID=1001 --build-arg GID=1002