### PR TITLE
Add support for "specials" season

### DIFF
--- a/mnamer/metadata.py
+++ b/mnamer/metadata.py
@@ -22,7 +22,7 @@ __all__ = ["Metadata", "MetadataMovie", "MetadataEpisode"]
 
 class _MetaFormatter(Formatter):
     def format_field(self, value, format_spec):
-        return format(value, format_spec) if value else ""
+        return format(value, format_spec) if value is not None else ""
 
     def get_value(self, key, args, kwargs):
         if isinstance(key, int):

--- a/tests/local/test_metadata.py
+++ b/tests/local/test_metadata.py
@@ -74,6 +74,11 @@ def test_metadata_episode__format_default():
     expected = "Spongebob Squarepants - 04x04"
     assert actual == expected
 
+def test_metadata_episode__specials():
+    metadata = MetadataEpisode(season=0, episode=1, series="Parks and Recreation")
+    actual = format(metadata, "{series} - {season:02}x{episode:02}")
+    expected = "Parks and Recreation - 00x01"
+    assert actual == expected
 
 def test_metadata_episode__format_with_specifiers():
     metadata = MetadataEpisode(


### PR DESCRIPTION
Season 0 is often used to signal specials seasons. mnamer was not properly formatting S0 due to a falsy check instead of a not None check.