### PR TITLE
Fix TVMaze Tests

### DIFF
--- a/tests/network/test_endpoints__tvmaze.py
+++ b/tests/network/test_endpoints__tvmaze.py
@@ -187,6 +187,8 @@ def test_tvmaze_show_episodes_list__success():
     for expected_episode_key in EXPECTED_EPISODE_KEYS:
         assert expected_episode_key in result
     for actual_key in result:
+        if actual_key == 'type':
+            continue
         assert actual_key in EXPECTED_EPISODE_KEYS
 
 


### PR DESCRIPTION
It looks like TVMaze has updated their episode list endpoint and have removed the type field from it. This wasn't used by mnamer so its not a big deal.