### PR TITLE
Adds support for moving with original filename (#43)

### DIFF
--- a/mnamer/metadata.py
+++ b/mnamer/metadata.py
@@ -45,6 +45,7 @@ class Metadata:
     quality: Optional[str] = None
     synopsis: Optional[str] = None
     media: Union[MediaType, str, None] = None
+    original: Optional[str] = None
 
     def __setattr__(self, key: str, value: Any):
         converter_map: Dict[str, Callable] = {

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -143,6 +143,7 @@ class Target:
             None: Metadata,
         }[media_type]
         self.metadata = meta_cls(language=self._settings.language)
+        self.metadata.original = self.source.name
         self.metadata.quality = (
             " ".join(
                 path_data[key]

--- a/tests/e2e/test_moving.py
+++ b/tests/e2e/test_moving.py
@@ -217,3 +217,15 @@ def test_ambiguous_language_deletction(e2e_run, setup_test_files):
     )
     result = e2e_run("--batch", ".")
     assert result.code == 0
+
+
+@pytest.mark.usefixtures("setup_test_dir")
+def test_original_filename(e2e_run, setup_test_files):
+    setup_test_files("archer.2009.s10e07.webrip.x264-lucidtv.mp4")
+    result = e2e_run(
+        "--batch",
+        "--episode-format='{original}'",
+        ".",
+    )
+    assert result.code == 0
+    assert "archer.2009.s10e07.webrip.x264-lucidtv.mp4" in result.out


### PR DESCRIPTION
I am not sure about {original} variable name. Maybe {original_filename} better? I just want to keep it one word like you did for [Field Variables](https://github.com/jkwill87/mnamer/wiki/Formatting#template-field-variables)