### PR TITLE
Add --language-fallback option for unknown subtitles

### DIFF
--- a/mnamer/frontends.py
+++ b/mnamer/frontends.py
@@ -121,20 +121,23 @@ class Cli(Frontend):
                 is_subtitle(target.metadata.container)
                 and not target.metadata.language_sub
             ):
-                if self.settings.batch:
-                    tty.msg(
-                        "skipping (subtitle language can't be detected)",
-                        MessageType.ALERT,
-                    )
-                    continue
-                try:
-                    target.metadata.language_sub = tty.subtitle_prompt()
-                except MnamerSkipException:
-                    tty.msg("skipping (user request)", MessageType.ALERT)
-                    continue
-                except MnamerAbortException:
-                    tty.msg("aborting (user request)", MessageType.ERROR)
-                    break
+                if self.settings.language_fallback:
+                    target.metadata.language_sub = self.settings.language_fallback
+                else:
+                    if self.settings.batch:
+                        tty.msg(
+                            "skipping (subtitle language can't be detected)",
+                            MessageType.ALERT,
+                        )
+                        continue
+                    try:
+                        target.metadata.language_sub = tty.subtitle_prompt()
+                    except MnamerSkipException:
+                        tty.msg("skipping (user request)", MessageType.ALERT)
+                        continue
+                    except MnamerAbortException:
+                        tty.msg("aborting (user request)", MessageType.ERROR)
+                        break
 
             # sanity check move
             if target.destination == target.source:

--- a/mnamer/frontends.py
+++ b/mnamer/frontends.py
@@ -122,7 +122,9 @@ class Cli(Frontend):
                 and not target.metadata.language_sub
             ):
                 if self.settings.language_fallback:
-                    target.metadata.language_sub = self.settings.language_fallback
+                    target.metadata.language_sub = (
+                        self.settings.language_fallback
+                    )
                 else:
                     if self.settings.batch:
                         tty.msg(

--- a/mnamer/frontends.py
+++ b/mnamer/frontends.py
@@ -121,25 +121,20 @@ class Cli(Frontend):
                 is_subtitle(target.metadata.container)
                 and not target.metadata.language_sub
             ):
-                if self.settings.language_fallback:
-                    target.metadata.language_sub = (
-                        self.settings.language_fallback
+                if self.settings.batch:
+                    tty.msg(
+                        "skipping (subtitle language can't be detected)",
+                        MessageType.ALERT,
                     )
-                else:
-                    if self.settings.batch:
-                        tty.msg(
-                            "skipping (subtitle language can't be detected)",
-                            MessageType.ALERT,
-                        )
-                        continue
-                    try:
-                        target.metadata.language_sub = tty.subtitle_prompt()
-                    except MnamerSkipException:
-                        tty.msg("skipping (user request)", MessageType.ALERT)
-                        continue
-                    except MnamerAbortException:
-                        tty.msg("aborting (user request)", MessageType.ERROR)
-                        break
+                    continue
+                try:
+                    target.metadata.language_sub = tty.subtitle_prompt()
+                except MnamerSkipException:
+                    tty.msg("skipping (user request)", MessageType.ALERT)
+                    continue
+                except MnamerAbortException:
+                    tty.msg("aborting (user request)", MessageType.ERROR)
+                    break
 
             # sanity check move
             if target.destination == target.source:

--- a/mnamer/setting_store.py
+++ b/mnamer/setting_store.py
@@ -107,6 +107,14 @@ class SettingStore:
             help="--language=<LANG>: specify the search language",
         )(),
     )
+    language_fallback: Optional[Language] = dataclasses.field(
+        default=None,
+        metadata=SettingSpec(
+            flags=["--language-fallback"],
+            group=SettingType.PARAMETER,
+            help="--language-fallback=<LANG>: specify the default language for subtitles",
+        )(),
+    )
     mask: List[str] = dataclasses.field(
         default_factory=lambda: [
             "avi",
@@ -373,6 +381,7 @@ class SettingStore:
             "episode_api": ProviderType,
             "episode_directory": self._resolve_path,
             "language": Language.parse,
+            "language_fallback": Language.parse,
             "mask": normalize_containers,
             "media": MediaType,
             "movie_api": ProviderType,

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -174,7 +174,13 @@ class Target:
             except MnamerException:
                 pass
         try:
-            self.metadata.language_sub = path_data.get("subtitle_language")
+            sub_lang = path_data.get("subtitle_language")
+            sub_lang = (
+                sub_lang
+                if sub_lang is not None and sub_lang != "und"
+                else self._settings.language_fallback
+            )
+            self.metadata.language_sub = sub_lang
         except MnamerException:
             pass
         if self.metadata.media is MediaType.MOVIE:

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,7 @@ PARAMETERS:
   --hits=<NUMBER>: limit the maximum number of hits for each query
   --ignore=<PATTERN,...>: ignore files matching these regular expressions
   --language=<LANG>: specify the search language
+  --language-fallback=<LANG>: specify the default language for subtitles
   --mask=<EXTENSION,...>: only process given file types
   --no-guess: disable best guess; e.g. when no matches or network down
   --no-overwrite: prevent relocation if it would overwrite a file

--- a/tests/local/test_target.py
+++ b/tests/local/test_target.py
@@ -6,6 +6,7 @@ import pytest
 from mnamer.setting_store import SettingStore
 from mnamer.target import *
 from mnamer.types import MediaType
+from mnamer.language import Language
 
 pytestmark = pytest.mark.local
 
@@ -102,6 +103,14 @@ def test_ambiguous_subtitle_language():
         Path("Subs/Nancy.Drew.S01E01.WEBRip.x264-ION10.srt"), SettingStore()
     )
     assert target.metadata.language is None
+
+
+def test_ambiguous_subtitle_language_fallback():
+    target = Target(
+        Path("Subs/Nancy.Drew.S01E01.WEBRip.x264-ION10.srt"),
+        SettingStore(language_fallback="en"),
+    )
+    assert target.metadata.language_sub == Language("English", "en", "eng")
 
 
 def test_destination__simple():

--- a/tests/local/test_target.py
+++ b/tests/local/test_target.py
@@ -102,7 +102,7 @@ def test_ambiguous_subtitle_language():
     target = Target(
         Path("Subs/Nancy.Drew.S01E01.WEBRip.x264-ION10.srt"), SettingStore()
     )
-    assert target.metadata.language is None
+    assert target.metadata.language_sub is None
 
 
 def test_ambiguous_subtitle_language_fallback():


### PR DESCRIPTION
This is a potential solution for #118. This works for my use case (having a ton of unprocessed `.srt` files that should be treated as English), but I understand if this is not an option you want to have.

Also I am not really a python person so if something is off please let me know 🙂 .