### PR TITLE
Bugfix: Annotate VERSION const type

### DIFF
--- a/mnamer/const.py
+++ b/mnamer/const.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from platform import platform, python_version
 from sys import argv, gettrace, version_info
 
+VERSION: str
+
 try:
     from mnamer.__version__ import __version__ as VERSION  # type: ignore
 except ModuleNotFoundError:


### PR DESCRIPTION
Python is not able to infer the type of `VERSION` due to its dynamic import. This changeset specifies the type explicitly.