### PR TITLE
Add --watch param to watch targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ PARAMETERS:
   -r, --recurse: search for files within nested directories
   -s, --scene: use dots in place of alphanumeric chars
   -v, --verbose: increase output verbosity
+  -w, --watch: watch target(s) for changes
   --hits=<NUMBER>: limit the maximum number of hits for each query
   --ignore=<PATTERN,...>: ignore files matching these regular expressions
   --language=<LANG>: specify the search language

--- a/mnamer/setting_store.py
+++ b/mnamer/setting_store.py
@@ -80,6 +80,15 @@ class SettingStore:
             help="-v, --verbose: increase output verbosity",
         ).as_dict(),
     )
+    watch: bool = dataclasses.field(
+        default=False,
+        metadata=SettingSpec(
+            action="store_true",
+            flags=["--watch", "-w"],
+            group=SettingType.PARAMETER,
+            help="-w, --watch: watch target(s) for changes",
+        ).as_dict(),
+    )
     hits: int = dataclasses.field(
         default=5,
         metadata=SettingSpec(

--- a/mnamer/tty.py
+++ b/mnamer/tty.py
@@ -76,9 +76,9 @@ def msg(
     if debug and not verbose:
         return
     if no_style:
-        print(_msg_format(body))
+        print(_msg_format(body), flush=True)
     else:
-        style_print(_msg_format(body), style=message_type.value)
+        style_print(_msg_format(body), style=message_type.value, flush=True)
 
 
 def error(body: Any):

--- a/mnamer/utils.py
+++ b/mnamer/utils.py
@@ -68,29 +68,19 @@ def filename_replace(filename: str, replacements: dict[str, str]) -> str:
     return base + container
 
 
-def filter_blacklist(paths: list[Path], blacklist: list[str]) -> list[Path]:
+def filter_blacklist(file_path: Path, blacklist: list[str]) -> bool:
     """Filters (set difference) paths by a collection of regex pattens."""
-    return [
-        path.absolute()
-        for path in paths
-        if not any(
-            re.search(pattern, str(path), re.IGNORECASE)
-            for pattern in blacklist
-            if pattern
-        )
-    ]
+    return not any(
+        re.search(pattern, str(file_path), re.IGNORECASE)
+        for pattern in blacklist
+        if pattern
+    )
 
 
-def filter_containers(
-    file_paths: list[Path], valid_containers: list[str]
-) -> list[Path]:
+def filter_containers(file_path: Path, valid_containers: list[str]) -> bool:
     """Filters (set intersection) a collection of containers."""
     valid_containers = normalize_containers(valid_containers)
-    return [
-        file_path
-        for file_path in file_paths
-        if not valid_containers or file_path.suffix.lower() in valid_containers
-    ]
+    return not valid_containers or file_path.suffix.lower() in valid_containers
 
 
 def findall(s, ss) -> Iterator[int]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests_cache ~= 0.9.7
 setuptools_scm ~= 7.1.0
 teletype ~= 1.3.4
 typing-extensions ~= 4.7.1
+watchdog ~= 3.0.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -36,6 +36,7 @@ DEFAULT_SETTINGS = {
     "test": False,
     "verbose": False,
     "version": False,
+    "watch": False,
 }
 
 

--- a/tests/local/test_utils.py
+++ b/tests/local/test_utils.py
@@ -305,7 +305,9 @@ def test_str_scenify__utf8_to_ascii():
 @pytest.mark.parametrize("sequence", (list(), set(), tuple()))
 def test_filter_blacklist__filter_none(sequence):
     expected = FILTER_FILENAMES
-    actual = filter_blacklist(FILTER_FILENAMES, sequence)
+    actual = list(
+        filter(lambda file: filter_blacklist(file, sequence), FILTER_FILENAMES)
+    )
     assert actual == expected
 
 
@@ -313,7 +315,9 @@ def test_filter_blacklist__filter_multiple_paths_single_pattern():
     expected = paths_except_for(
         "Images/Photos/DCM0001.jpg", "Images/Photos/DCM0002.jpg"
     )
-    actual = filter_blacklist(FILTER_FILENAMES, ["dcm"])
+    actual = list(
+        filter(lambda file: filter_blacklist(file, ["dcm"]), FILTER_FILENAMES)
+    )
     assert actual == expected
 
 
@@ -323,7 +327,11 @@ def test_filter_blacklist__filter_multiple_paths_multiple_patterns():
         "Downloads/the.goonies.1985.sample.mp4",
         "Sample/the mandalorian s01x02.mp4",
     )
-    actual = filter_blacklist(FILTER_FILENAMES, ["temp", "sample"])
+    actual = list(
+        filter(
+            lambda file: filter_blacklist(file, ["temp", "sample"]), FILTER_FILENAMES
+        )
+    )
     assert actual == expected
 
 
@@ -331,7 +339,7 @@ def test_filter_blacklist__filter_single_path_single_pattern():
     expected = paths_except_for(
         "Images/sample.file.mp4", "Sample/the mandalorian s01x02.mp4"
     )
-    actual = filter_blacklist(expected, ["sample"])
+    actual = list(filter(lambda file: filter_blacklist(file, ["sample"]), expected))
     assert actual == expected
 
 
@@ -339,7 +347,9 @@ def test_filter_blacklist__filter_single_path_multiple_patterns():
     expected = paths_except_for(
         "Images/sample.file.mp4", "Sample/the mandalorian s01x02.mp4"
     )
-    actual = filter_blacklist(expected, ["files", "sample"])
+    actual = list(
+        filter(lambda file: filter_blacklist(file, ["files", "sample"]), expected)
+    )
     assert expected == actual
 
 
@@ -360,13 +370,15 @@ def test_filter_blacklist__regex():
         "made up movie.mp4",
         "made up show s01e10.mkv",
     )
-    actual = filter_blacklist(FILTER_FILENAMES, [pattern])
+    actual = list(
+        filter(lambda file: filter_blacklist(file, [pattern]), FILTER_FILENAMES)
+    )
     assert actual == expected
 
 
 def test_filter_containers__filter_none():
     expected = FILTER_FILENAMES
-    actual = filter_containers(FILTER_FILENAMES, [])
+    actual = list(filter(lambda file: filter_containers(file, []), FILTER_FILENAMES))
     assert expected == actual
 
 
@@ -375,7 +387,9 @@ def test_filter_containers__filter_multiple_paths_single_pattern(
     containers: list[str],
 ):
     expected = paths_for("Images/Photos/DCM0001.jpg", "Images/Photos/DCM0002.jpg")
-    actual = filter_containers(FILTER_FILENAMES, containers)
+    actual = list(
+        filter(lambda file: filter_containers(file, containers), FILTER_FILENAMES)
+    )
     assert expected == actual
 
 
@@ -393,7 +407,9 @@ def test_filter_containers__filter_multiple_paths_multi_pattern(
         "s.w.a.t.2017.s02e01.mkv",
         "temp.zip",
     )
-    actual = filter_containers(FILTER_FILENAMES, containers)
+    actual = list(
+        filter(lambda file: filter_containers(file, containers), FILTER_FILENAMES)
+    )
     assert expected == actual
 
 
@@ -403,7 +419,7 @@ def test_filter_containers__filter_single_path_multi_pattern(
 ):
     filepaths = paths_for("Images/Skiing Trip.mp4")
     expected = filepaths
-    actual = filter_containers(filepaths, containers)
+    actual = list(filter(lambda file: filter_containers(file, containers), filepaths))
     assert expected == actual
 
 


### PR DESCRIPTION
Changes:

* Adds a `--watch` param to watch targets
* Added `watchdog` lib
* Refactored a couple of methods that passed a list so that a single item can be passed
* Add `flush=True` when printing as without it, the watch thread wasn't outputting prints