### PR TITLE
Remove too early metadata language definition without try-except block

### DIFF
--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -164,14 +164,12 @@ class Target:
             )
             or None
         )
-        self.metadata.language = path_data.get("language")
         self.metadata.group = path_data.get("release_group")
         self.metadata.container = file_path.suffix or None
-        if not self.metadata.language:
-            try:
-                self.metadata.language = path_data.get("language")
-            except MnamerException:
-                pass
+        try:
+            self.metadata.language = path_data.get("language")
+        except MnamerException:
+            pass
         try:
             self.metadata.language_sub = path_data.get("subtitle_language")
         except MnamerException:


### PR DESCRIPTION
Fixes: #289

Changes explaination:
- definition of self.metadata.language throws MnamerException if path_data.get("language") is not a valid language (in my case it was the German word "und", which means "and" and is not a language reference at all)
- later if condition isn't necessary because self.metadata.language will never be set before
- try-except block used makes sure that path_data.get("language") can be converted to a Language, otherwise the metadata language will not be set