### PR TITLE
More date options

### DIFF
--- a/mnamer/endpoints.py
+++ b/mnamer/endpoints.py
@@ -165,7 +165,7 @@ def tmdb_movies(
 def tmdb_search_movies(
     api_key: str,
     title: str,
-    year: int | str | None = None,
+    year: int | None = None,
     language: Language | None = None,
     region: str | None = None,
     adult: bool = False,

--- a/mnamer/metadata.py
+++ b/mnamer/metadata.py
@@ -121,8 +121,15 @@ class MetadataMovie(Metadata):
     def __format__(self, format_spec: str | None):
         default = "{name} ({date.year})"
         re_pattern = r"({(\w+)(?:\[[\w:]+\]|\.\w+)?(?:\:\d{1,2})?})"
+        tname = ''
+        if ( format_spec is None or re.search("{(date.year|date)}", format_spec) is not None ) \
+           and self.name is not None and self.date is not None \
+           and self.name.endswith(f" ({self.date.year})"):
+            tname = f" ({self.date.year})"
+            self.name = self.name[:-len(tname)]
         s = re.sub(re_pattern, self._format_repl, format_spec or default)
         s = str_fix_padding(s)
+        self.name+=tname
         return s
 
     def __setattr__(self, key: str, value: Any):
@@ -165,8 +172,15 @@ class MetadataEpisode(Metadata):
     def __format__(self, format_spec: str | None):
         default = "{series} - {season:02}x{episode:02} - {title}"
         re_pattern = r"({(\w+)(?:\[[\w:]+\]|\.\w+)?(?:\:\d{1,2})?})"
+        tseries = ''
+        if ( format_spec is None or re.search("{(series_date.year|series_date|date.year|date)}", format_spec) is not None ) \
+           and self.series is not None and self.series_date is not None \
+           and self.series.endswith(f" ({self.series_date.year})"):
+            tseries = f" ({self.series_date.year})"
+            self.series = self.series[:-len(tseries)]
         s = re.sub(re_pattern, self._format_repl, format_spec or default)
         s = str_fix_padding(s)
+        self.series+=tseries
         return s
 
     def __setattr__(self, key: str, value: Any):

--- a/mnamer/metadata.py
+++ b/mnamer/metadata.py
@@ -158,7 +158,7 @@ class MetadataEpisode(Metadata):
 
     def __format__(self, format_spec: str | None):
         default = "{series} - {season:02}x{episode:02} - {title}"
-        re_pattern = r"({(\w+)(?:\[[\w:]+\])?(?:\:\d{1,2})?})"
+        re_pattern = r"({(\w+)(?:\[[\w:]+\]|\.\w+)?(?:\:\d{1,2})?})"
         s = re.sub(re_pattern, self._format_repl, format_spec or default)
         s = str_fix_padding(s)
         return s

--- a/mnamer/metadata.py
+++ b/mnamer/metadata.py
@@ -16,7 +16,6 @@ from mnamer.utils import (
     str_fix_padding,
     str_replace_slashes,
     str_title_case,
-    year_parse,
 )
 
 
@@ -111,13 +110,17 @@ class MetadataMovie(Metadata):
     """
 
     name: str | None = None
-    year: str | None = None
+    date: dt.date | None = None
     id_imdb: str | None = None
     id_tmdb: str | None = None
 
+    def __post_init__(self):
+        if isinstance(self.date, str):
+            self.date = parse_date(self.date)
+
     def __format__(self, format_spec: str | None):
-        default = "{name} ({year})"
-        re_pattern = r"({(\w+)(?:\[[\w:]+\])?(?:\:\d{1,2})?})"
+        default = "{name} ({date.year})"
+        re_pattern = r"({(\w+)(?:\[[\w:]+\]|\.\w+)?(?:\:\d{1,2})?})"
         s = re.sub(re_pattern, self._format_repl, format_spec or default)
         s = str_fix_padding(s)
         return s
@@ -125,7 +128,7 @@ class MetadataMovie(Metadata):
     def __setattr__(self, key: str, value: Any):
         converter_map: dict[str, Callable] = {
             "name": fn_pipe(str_replace_slashes, str_title_case),
-            "year": year_parse,
+            "date": parse_date,
         }
         converter: Callable | None = converter_map.get(key)
         if value is not None and converter:
@@ -141,6 +144,7 @@ class MetadataEpisode(Metadata):
     """
 
     series: str | None = None
+    series_date: dt.date | None = None
     season: int | None = None
     episode: int | None = None
     date: dt.date | None = None
@@ -155,6 +159,8 @@ class MetadataEpisode(Metadata):
             self.episode = int(self.episode)
         if isinstance(self.date, str):
             self.date = parse_date(self.date)
+        if isinstance(self.series_date, str):
+            self.series_date = parse_date(self.series_date)
 
     def __format__(self, format_spec: str | None):
         default = "{series} - {season:02}x{episode:02} - {title}"
@@ -169,6 +175,7 @@ class MetadataEpisode(Metadata):
             "episode": int,
             "season": int,
             "series": fn_pipe(str_replace_slashes, str_title_case),
+            "series_date": fn_pipe(str_replace_slashes, str_title_case),
             "title": fn_pipe(str_replace_slashes, str_title_case),
         }
         converter: Callable | None = converter_map.get(key)

--- a/mnamer/metadata.py
+++ b/mnamer/metadata.py
@@ -175,7 +175,7 @@ class MetadataEpisode(Metadata):
             "episode": int,
             "season": int,
             "series": fn_pipe(str_replace_slashes, str_title_case),
-            "series_date": fn_pipe(str_replace_slashes, str_title_case),
+            "series_date": parse_date,
             "title": fn_pipe(str_replace_slashes, str_title_case),
         }
         converter: Callable | None = converter_map.get(key)

--- a/mnamer/providers.py
+++ b/mnamer/providers.py
@@ -334,14 +334,16 @@ class Tvdb(Provider):
         found = False
         for meta in self._search_id(id_tvdb, language=language):
             if meta.date:
-                if season is not None and season == meta.season and episode is not None and episode == meta.episode:
+                if season is not None and season == meta.season \
+                   and episode is not None and episode == meta.episode:
                     if meta.date == release_date:
                         found = True
                         yield meta
-                    elif release_date.month == 1 and release_date.month == 1:
-                        if meta.date.year == release_date.year or meta.series_date.year == release_date.year:
-                            found = True
-                            yield meta
+                    elif release_date.month == 1 and release_date.month == 1 and \
+                         ( meta.date.year == release_date.year or \
+                           meta.series_date.year == release_date.year ):
+                        found = True
+                        yield meta
                 else:
                     if meta.date == release_date:
                         found = True

--- a/mnamer/providers.py
+++ b/mnamer/providers.py
@@ -28,7 +28,7 @@ from mnamer.language import Language
 from mnamer.metadata import Metadata, MetadataEpisode, MetadataMovie
 from mnamer.setting_store import SettingStore
 from mnamer.types import MediaType, ProviderType
-from mnamer.utils import parse_date, year_range_parse
+from mnamer.utils import parse_date
 
 
 class Provider(ABC):
@@ -83,7 +83,7 @@ class Omdb(Provider):
         if query.id_imdb:
             results = self._lookup_movie(query.id_imdb)
         elif query.name:
-            results = self._search_movie(query.name, query.year)
+            results = self._search_movie(query.name, query.date.year)
         else:
             raise MnamerNotFoundException
         yield from results
@@ -94,15 +94,17 @@ class Omdb(Provider):
         try:
             release_date = dt.datetime.strptime(
                 response["Released"], "%d %b %Y"
-            ).strftime("%Y-%m-%d")
+            )
         except (KeyError, ValueError):
             if response.get("Year") in (None, "N/A"):
                 release_date = None
             else:
-                release_date = "{}-01-01".format(response["Year"])
+                release_date = dt.datetime.strptime(
+                    "{}-01-01".format(response["Year"]), "%Y-%m-%d"
+                )
         meta = MetadataMovie(
             name=response["Title"],
-            year=release_date,
+            date=release_date,
             synopsis=response["Plot"],
             id_imdb=response["imdbID"],
         )
@@ -110,9 +112,9 @@ class Omdb(Provider):
             meta.synopsis = None
         yield meta
 
-    def _search_movie(self, name: str, year: str | None) -> Iterator[MetadataMovie]:
+    def _search_movie(self, name: str, year: int | None) -> Iterator[MetadataMovie]:
         assert self.api_key
-        year_from, year_to = year_range_parse(year, 5)
+        year_from, year_to = year - 5, year + 5
         found = False
         page = 1
         page_max = 10  # each page yields a maximum of 10 results
@@ -153,7 +155,7 @@ class Tmdb(Provider):
         if query.id_tmdb:
             results = self._search_id(query.id_tmdb, query.language)
         elif query.name:
-            results = self._search_name(query.name, query.year, query.language)
+            results = self._search_name(query.name, query.date.year, query.language)
         else:
             raise MnamerNotFoundException
         yield from results
@@ -166,13 +168,13 @@ class Tmdb(Provider):
         yield MetadataMovie(
             name=response["title"],
             language=language,
-            year=response["release_date"],
+            date=response["release_date"],
             synopsis=response["overview"],
             id_tmdb=response["id"],
             id_imdb=response["imdb_id"],
         )
 
-    def _search_name(self, name: str, year: str | None, language: Language | None):
+    def _search_name(self, name: str, year: int | None, language: Language | None):
         assert self.api_key
         page = 1
         page_max = 5  # each page yields a maximum of 20 results
@@ -193,7 +195,7 @@ class Tmdb(Provider):
                         name=entry["title"],
                         language=language,
                         synopsis=entry["overview"],
-                        year=entry["release_date"],
+                        date=entry["release_date"],
                     )
                     if not meta.year:
                         continue
@@ -275,6 +277,7 @@ class Tvdb(Provider):
                         id_tvdb=id_tvdb,
                         season=entry["airedSeason"],
                         series=series_data["data"]["seriesName"],
+                        series_date=series_data["data"]["firstAired"],
                         language=language,
                         synopsis=(entry["overview"] or "")
                         .replace("\r\n", "")
@@ -480,6 +483,7 @@ class TvMaze(Provider):
             id_tvmaze=id_tvmaze or None,
             season=episode_entry["season"],
             series=series_entry["name"],
+            series_date=series_entry["premiered"],
             synopsis=episode_entry["summary"] or None,
             title=episode_entry["name"] or None,
         )

--- a/mnamer/providers.py
+++ b/mnamer/providers.py
@@ -83,7 +83,7 @@ class Omdb(Provider):
         if query.id_imdb:
             results = self._lookup_movie(query.id_imdb)
         elif query.name:
-            results = self._search_movie(query.name, query.date.year)
+            results = self._search_movie(query.name, None if query.date is None else query.date.year)
         else:
             raise MnamerNotFoundException
         yield from results
@@ -155,7 +155,7 @@ class Tmdb(Provider):
         if query.id_tmdb:
             results = self._search_id(query.id_tmdb, query.language)
         elif query.name:
-            results = self._search_name(query.name, query.date.year, query.language)
+            results = self._search_name(query.name, None if query.date is None else query.date.year, query.language)
         else:
             raise MnamerNotFoundException
         yield from results
@@ -197,7 +197,7 @@ class Tmdb(Provider):
                         synopsis=entry["overview"],
                         date=entry["release_date"],
                     )
-                    if not meta.year:
+                    if not meta.date:
                         continue
                     yield meta
                     found = True

--- a/mnamer/setting_store.py
+++ b/mnamer/setting_store.py
@@ -177,7 +177,7 @@ class SettingStore:
         ).as_dict(),
     )
     movie_format: str = dataclasses.field(
-        default="{name} ({year}).{extension}",
+        default="{name} ({date.year}).{extension}",
         metadata=SettingSpec(
             dest="movie_format",
             flags=["--movie_format", "--movie-format", "--movieformat"],

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -167,6 +167,10 @@ class Target:
         self.metadata.language = path_data.get("language")
         self.metadata.group = path_data.get("release_group")
         self.metadata.container = file_path.suffix or None
+        if "date" in path_data:
+            self.metadata.date = path_data.get("date")
+        elif "year" in path_data:
+            self.metadata.date = "{}-01-01".format(path_data.get("year"))
         if not self.metadata.language:
             try:
                 self.metadata.language = path_data.get("language")
@@ -178,9 +182,7 @@ class Target:
             pass
         if isinstance(self.metadata, MetadataMovie):
             self.metadata.name = path_data.get("title")
-            self.metadata.date = path_data.get("date")
         elif isinstance(self.metadata, MetadataEpisode):
-            self.metadata.date = path_data.get("date")
             self.metadata.episode = path_data.get("episode")
             self.metadata.season = path_data.get("season")
             self.metadata.series = path_data.get("title")

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -178,7 +178,7 @@ class Target:
             pass
         if isinstance(self.metadata, MetadataMovie):
             self.metadata.name = path_data.get("title")
-            self.metadata.year = path_data.get("year")
+            self.metadata.date = path_data.get("date")
         elif isinstance(self.metadata, MetadataEpisode):
             self.metadata.date = path_data.get("date")
             self.metadata.episode = path_data.get("episode")

--- a/mnamer/utils.py
+++ b/mnamer/utils.py
@@ -476,30 +476,3 @@ def str_title_case(s: str) -> str:
                 s = s[:pos] + exception.upper() + s[pos + word_length :]
 
     return s
-
-
-def year_parse(s: str) -> int | None:
-    """Parses a year from a string."""
-    regex = r"((?:19|20)\d{2})(?:$|[-/]\d{2}[-/]\d{2})"
-    try:
-        return int(re.findall(regex, str(s))[0])
-    except IndexError:
-        return None
-
-
-def year_range_parse(years: str | int | None, tolerance: int = 1) -> tuple[int, int]:
-    """Parses a year or dash-delimited year range."""
-    regex = r"^((?:19|20)\d{2})?([-,: ]*)?((?:19|20)\d{2})?$"
-    default_start = 1900
-    default_end = CURRENT_YEAR
-    try:
-        start, dash, end = re.match(regex, str(years).strip()).groups()  # type: ignore
-    except AttributeError:
-        start, end, dash = None, None, True
-    if not start and not end:
-        start, end, dash = None, None, True
-    start = int(start or default_start)
-    end = int(end or default_end)
-    if not dash:
-        end = start
-    return start - tolerance, end + tolerance


### PR DESCRIPTION
Changes year in movies to a date, adds a series_date for when the matched series first aired, and add the capability to use the datetime attributes for formatting like so: `{date.year}`, `{date.month}`, or `{series_date.year}`. This would make formatting series conform to for example jellyfin show naming more.