### PR TITLE
fix: Allow absolute episode numbering

### DIFF
--- a/mnamer/endpoints.py
+++ b/mnamer/endpoints.py
@@ -343,7 +343,7 @@ def tvdb_series_id_episodes_query(
     headers = {"Authorization": f"Bearer {token}"}
     if language:
         headers["Accept-Language"] = language.a2
-    parameters = {"airedSeason": season, "airedEpisode": episode, "page": page}
+    parameters = {"absoluteNumber": episode} if season is None else {"airedSeason": season, "airedEpisode": episode, "page": page}
     status, content = request_json(
         url,
         parameters,


### PR DESCRIPTION
When a file contained an episode number but no season number, the lookup would fail if --no-guess was enabled. This was a problem for many anime series (e.g., Naruto Shippuuden), where releases often use absolute numbering.

With this change the episodes can matches correctly without requiring a season number.

Example:
Processing Episode "Naruto Shippuuden 249 [1080p BD AV1 Dual Audio].mkv" (363.99MB)
