### PR TITLE
Fix requests_cache version check for 1.3.0

### DIFF
--- a/mnamer/const.py
+++ b/mnamer/const.py
@@ -4,6 +4,7 @@ import datetime as dt
 from pathlib import Path
 from platform import platform, python_version
 from sys import argv, gettrace, version_info
+from importlib.metadata import version as pkg_version, PackageNotFoundError
 
 VERSION: str
 
@@ -37,8 +38,8 @@ except ModuleNotFoundError:
     requests_version = "N/A"
 
 try:
-    from requests_cache import __version__ as requests_cache_version
-except ModuleNotFoundError:
+    requests_cache_version = pkg_version('requests_cache')
+except PackageNotFoundError:
     requests_cache_version = "N/A"
 
 try:


### PR DESCRIPTION
Using the same method provided here : https://github.com/requests-cache/requests-cache/commit/61fae61e07222777eb26a6fb670c4ee6a9cdddb7

Intended to fix https://github.com/jkwill87/mnamer/issues/332 and unblock https://github.com/jkwill87/mnamer/pull/316