### PR TITLE
Make network test key assertions resilient to additive API changes

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Testing (contributor)
         uses: ./.github/actions/test
         if: github.actor != 'dependabot[bot]'
+        env:
+          API_KEY_OMDB: ${{ secrets.API_KEY_OMDB }}
         with:
           local: true
           network: true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,6 +27,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/init
       - uses: ./.github/actions/test
+        env:
+          API_KEY_OMDB: ${{ secrets.API_KEY_OMDB }}
         with:
           local: true
           network: true

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from collections.abc import Mapping, Set
 from typing import Any, NamedTuple
 
 from mnamer.const import SUBTITLE_CONTAINERS
@@ -120,3 +121,8 @@ class MockRequestResponse:
         from json import loads
 
         return loads(self.content)
+
+
+def assert_has_keys(actual: Mapping[str, object], expected: Set[str]) -> None:
+    """Assert every key in `expected` is present in `actual`; extras are ignored."""
+    assert expected <= actual.keys(), expected - actual.keys()

--- a/tests/network/test_endpoints__omdb.py
+++ b/tests/network/test_endpoints__omdb.py
@@ -5,7 +5,7 @@ import pytest
 from mnamer.endpoints import omdb_search, omdb_title
 from mnamer.exceptions import MnamerException, MnamerNotFoundException
 from mnamer.providers import Omdb
-from tests import JUNK_TEXT, MockRequestResponse
+from tests import JUNK_TEXT, MockRequestResponse, assert_has_keys
 
 pytestmark = [
     pytest.mark.network,
@@ -73,7 +73,7 @@ def test_omdb_title__media__movie():
         "Year",
     }
     result = omdb_title(Omdb.api_key, media="movie", title="ninja turtles")
-    assert expected_top_level_keys.issuperset(set(result.keys()))
+    assert_has_keys(result, expected_top_level_keys)
     assert result["Response"]
     assert result["Type"] == "movie"
     assert result["Title"] == "Teenage Mutant Ninja Turtles"
@@ -106,7 +106,7 @@ def test_omdb_title__media__series():
     }
 
     result = omdb_title(Omdb.api_key, media="series", title="ninja turtles")
-    assert set(result.keys()).issuperset(expected_top_level_keys)
+    assert_has_keys(result, expected_top_level_keys)
     assert result["Response"]
     assert result["Type"] == "series"
     assert result["Title"] == "Teenage Mutant Ninja Turtles"
@@ -135,13 +135,13 @@ def test_omdb_title__invalid_plot():
 def test_omdb_search__fields__top_level():
     expected_fields = {"Search", "Response", "totalResults"}
     result = omdb_search(Omdb.api_key, "ninja turtles")
-    assert set(result.keys()) == expected_fields
+    assert_has_keys(result, expected_fields)
 
 
 def test_omdb_search__fields__search():
     expected_fields = {"Title", "Year", "imdbID", "Type", "Poster"}
     result = omdb_search(Omdb.api_key, "ninja turtles")["Search"][0]
-    assert set(result.keys()) == expected_fields
+    assert_has_keys(result, expected_fields)
 
 
 def test_omdb_search__query__movie():

--- a/tests/network/test_endpoints__tmdb.py
+++ b/tests/network/test_endpoints__tmdb.py
@@ -3,7 +3,7 @@ import pytest
 from mnamer.endpoints import tmdb_find, tmdb_movies, tmdb_search_movies
 from mnamer.exceptions import MnamerException, MnamerNotFoundException
 from mnamer.providers import Tmdb
-from tests import JUNK_TEXT, RUSSIAN_LANG
+from tests import JUNK_TEXT, RUSSIAN_LANG, assert_has_keys
 
 pytestmark = [
     pytest.mark.network,
@@ -36,6 +36,7 @@ def test_tmdb_find__imdb_success():
         "poster_path",
         "popularity",
         "release_date",
+        "softcore",
         "title",
         "video",
         "vote_average",
@@ -43,11 +44,9 @@ def test_tmdb_find__imdb_success():
     }
     result = tmdb_find(Tmdb.api_key, "imdb_id", GOONIES_IMDB_ID)
     assert isinstance(result, dict)
-    assert set(result.keys()).issuperset(expected_top_level_keys)
+    assert_has_keys(result, expected_top_level_keys)
     assert len(result.get("movie_results", {})) > 0
-    assert expected_movie_results_keys.issuperset(
-        set(result.get("movie_results", {})[0].keys())
-    )
+    assert_has_keys(result["movie_results"][0], expected_movie_results_keys)
 
 
 def test_tmdb_find__api_key_fail():
@@ -105,7 +104,7 @@ def test_tmdb_movies__success():
     }
     result = tmdb_movies(Tmdb.api_key, GOONIES_TMDB_ID)
     assert isinstance(result, dict)
-    assert set(result.keys()).issuperset(expected_top_level_keys)
+    assert_has_keys(result, expected_top_level_keys)
     assert result.get("title") == "The Goonies"
 
 
@@ -148,6 +147,7 @@ def test_tmdb_search_movies__success():
         "popularity",
         "poster_path",
         "release_date",
+        "softcore",
         "title",
         "video",
         "vote_average",
@@ -155,9 +155,9 @@ def test_tmdb_search_movies__success():
     }
     result = tmdb_search_movies(Tmdb.api_key, "the goonies", 1985)
     assert isinstance(result, dict)
-    assert set(result.keys()).issuperset(expected_top_level_keys)
+    assert_has_keys(result, expected_top_level_keys)
     assert isinstance(result["results"], list)
-    assert expected_results_keys.issuperset(set(result.get("results", [{}])[0].keys()))
+    assert_has_keys(result["results"][0], expected_results_keys)
     assert result["results"][0]["original_title"] == "The Goonies"
     result = tmdb_search_movies(Tmdb.api_key, "the goonies")
     assert len(result["results"]) > 1

--- a/tests/network/test_endpoints__tvdb.py
+++ b/tests/network/test_endpoints__tvdb.py
@@ -12,7 +12,7 @@ from mnamer.endpoints import (
 from mnamer.exceptions import MnamerException, MnamerNotFoundException
 from mnamer.language import Language
 from mnamer.providers import Tvdb
-from tests import JUNK_TEXT, RUSSIAN_LANG
+from tests import JUNK_TEXT, RUSSIAN_LANG, assert_has_keys
 
 pytestmark = [
     pytest.mark.network,
@@ -122,7 +122,7 @@ def test_tvdb_episodes_id__success(tvdb_token):
     result = tvdb_episodes_id(tvdb_token, LOST_TVDB_ID_EPISODE)
     assert isinstance(result, dict)
     assert "data" in result
-    assert set(result["data"].keys()) == EXPECTED_TOP_LEVEL_SHOW_KEYS
+    assert_has_keys(result["data"], EXPECTED_TOP_LEVEL_SHOW_KEYS)
     assert str(result["data"]["seriesId"]) == LOST_TVDB_ID_SERIES
     assert str(result["data"]["id"]) == LOST_TVDB_ID_EPISODE
 
@@ -198,7 +198,7 @@ def test_tvdb_series_id__success(tvdb_token):
     result = tvdb_series_id(tvdb_token, LOST_TVDB_ID_SERIES)
     assert isinstance(result, dict)
     assert "data" in result
-    assert set(result["data"].keys()) == expected_top_level_keys
+    assert_has_keys(result["data"], expected_top_level_keys)
     assert str(result["data"]["id"]) == LOST_TVDB_ID_SERIES
     assert result["data"]["seriesName"] == "Lost"
 
@@ -239,7 +239,7 @@ def test_tvdb_series_id_episodes__success(tvdb_token):
     assert isinstance(result, dict)
     assert "data" in result
     entry = result["data"][0]
-    assert set(entry.keys()) == EXPECTED_TOP_LEVEL_SHOW_KEYS
+    assert_has_keys(entry, EXPECTED_TOP_LEVEL_SHOW_KEYS)
     assert str(entry["id"]) == LOST_TVDB_ID_EPISODE
 
 
@@ -302,8 +302,7 @@ def test_tvdb_series_id_episodes_query__success_id_tvdb(tvdb_token):
     assert "data" in result
     data = result["data"]
     assert len(data) == 100
-    actual_top_level_keys = set(data[0].keys())
-    assert actual_top_level_keys == EXPECTED_TOP_LEVEL_SHOW_KEYS
+    assert_has_keys(data[0], EXPECTED_TOP_LEVEL_SHOW_KEYS)
     assert str(data[0]["id"]) == LOST_TVDB_ID_EPISODE
 
 
@@ -312,8 +311,7 @@ def test_tvdb_series_id_episodes_query__success_id_tvdb_season(tvdb_token):
     assert isinstance(result, dict)
     assert "data" in result
     data = result["data"]
-    actual_top_level_keys = set(data[0].keys())
-    assert actual_top_level_keys == EXPECTED_TOP_LEVEL_SHOW_KEYS
+    assert_has_keys(data[0], EXPECTED_TOP_LEVEL_SHOW_KEYS)
     assert str(data[0]["id"]) == LOST_TVDB_ID_EPISODE
     assert result["links"]["prev"] is None
     assert result["links"]["next"] is None
@@ -328,8 +326,7 @@ def test_tvdb_series_id_episodes_query__success_id_tvdb_season_episode(
     assert isinstance(result, dict)
     assert "data" in result
     data = result["data"]
-    actual_top_level_keys = set(data[0].keys())
-    assert actual_top_level_keys == EXPECTED_TOP_LEVEL_SHOW_KEYS
+    assert_has_keys(data[0], EXPECTED_TOP_LEVEL_SHOW_KEYS)
     assert str(data[0]["id"]) == LOST_TVDB_ID_EPISODE
     assert result["links"]["prev"] is None
     assert result["links"]["next"] is None
@@ -385,8 +382,7 @@ def test_tvdb_search_series__success(tvdb_token):
     assert "data" in result
     data = result["data"]
     assert len(data) == 100
-    actual_top_level_keys = set(data[0].keys())
-    assert actual_top_level_keys == expected_top_level_keys
+    assert_has_keys(data[0], expected_top_level_keys)
 
 
 def test_tvdb_search_series__language(tvdb_token):

--- a/tests/network/test_endpoints__tvmaze.py
+++ b/tests/network/test_endpoints__tvmaze.py
@@ -10,7 +10,7 @@ from mnamer.endpoints import (
     tvmaze_show_single_search,
 )
 from mnamer.exceptions import MnamerException, MnamerNotFoundException
-from tests import EPISODE_META, JUNK_TEXT, TEST_DATE
+from tests import EPISODE_META, JUNK_TEXT, TEST_DATE, assert_has_keys
 
 pytestmark = [
     pytest.mark.network,
@@ -106,7 +106,7 @@ def test_tvmaze_show_search__success():
     expected_top_level_keys = {"score", "show"}
     assert results
     result = results[0]
-    assert expected_top_level_keys == set(result)
+    assert_has_keys(result, expected_top_level_keys)
     for expected_show_key in EXPECTED_SHOW_KEYS:
         assert expected_show_key in result["show"]
     assert result["show"]["id"] == META["id_tvmaze"]


### PR DESCRIPTION
Tests fail when new fields are added. This has become a maintenance burden. This PR updates tests so they only fail when known keys are removed, not when new ones are added.