### PR TITLE
Adopt Python 3.12+ typing and normalize API responses

### DIFF
--- a/mnamer/argument.py
+++ b/mnamer/argument.py
@@ -1,5 +1,5 @@
 import argparse
-from typing import Any
+from typing import Any, final, override
 
 from mnamer.const import USAGE
 from mnamer.setting_spec import SettingSpec
@@ -28,6 +28,7 @@ DIRECTIVES:
 """
 
 
+@final
 class ArgLoader(argparse.ArgumentParser):
     """
     An overridden ArgumentParser class which is build to accommodate mnamer's setting
@@ -49,7 +50,9 @@ class ArgLoader(argparse.ArgumentParser):
             SettingType.PARAMETER,
             SettingType.POSITIONAL,
         }
-        [self._add_spec(spec) for spec in specs if spec.group in groups]
+        for spec in specs:
+            if spec.group in groups:
+                self._add_spec(spec)
 
     def _add_spec(self, spec: SettingSpec):
         if spec.group is SettingType.PARAMETER:
@@ -63,7 +66,7 @@ class ArgLoader(argparse.ArgumentParser):
         args, kwargs = spec.registration
         if not args or not kwargs.get("help"):
             raise RuntimeError("Cannot register ArgumentSpec")
-        group.add_argument(*args, **kwargs)
+        _action = group.add_argument(*args, **kwargs)
 
     __iadd__ = _add_spec
 
@@ -73,6 +76,7 @@ class ArgLoader(argparse.ArgumentParser):
             raise RuntimeError(f"invalid arguments: {','.join(unknowns)}")
         return vars(load_arguments)
 
+    @override
     def format_help(self) -> str:
         """
         Overrides ArgumentParser's format_help to dynamically generate a help message

--- a/mnamer/const.py
+++ b/mnamer/const.py
@@ -5,46 +5,79 @@ from pathlib import Path
 from platform import platform, python_version
 from sys import argv, gettrace, version_info
 
-VERSION: str
 
-try:
-    from mnamer.__version__ import __version__ as VERSION  # type: ignore
-except ModuleNotFoundError:
-    from setuptools_scm import get_version  # type: ignore
+def _resolve_version() -> str:
+    try:
+        from mnamer.__version__ import __version__
 
-    VERSION = get_version(root="..", relative_to=__file__, local_scheme="dirty-tag")
+        return __version__
+    except ModuleNotFoundError:
+        from setuptools_scm import get_version  # type: ignore[import-untyped]
 
-try:
-    from appdirs import __version__ as appdirs_version  # type: ignore
-except ModuleNotFoundError:
-    appdirs_version = "N/A"
+        return get_version(root="..", relative_to=__file__, local_scheme="dirty-tag")
 
-try:
-    from appdirs import user_cache_dir
 
-    cache_dir = user_cache_dir()
-except ModuleNotFoundError:
-    cache_dir = "N/A"
+def _resolve_appdirs_version() -> str:
+    try:
+        from appdirs import __version__  # type: ignore[import-untyped]
 
-try:
-    from guessit import __version__ as guessit_version  # type: ignore
-except ModuleNotFoundError:
-    guessit_version = "N/A"
+        return __version__
+    except ModuleNotFoundError:
+        return "N/A"
 
-try:
-    from requests import __version__ as requests_version
-except ModuleNotFoundError:
-    requests_version = "N/A"
 
-try:
-    from requests_cache import __version__ as requests_cache_version
-except ModuleNotFoundError:
-    requests_cache_version = "N/A"
+def _resolve_cache_dir() -> str:
+    try:
+        from appdirs import user_cache_dir  # type: ignore[import-untyped]
 
-try:
-    from teletype import VERSION as teletype_version
-except ModuleNotFoundError:
-    teletype_version = "N/A"
+        return user_cache_dir()
+    except ModuleNotFoundError:
+        return "N/A"
+
+
+def _resolve_guessit_version() -> str:
+    try:
+        from guessit import __version__  # type: ignore[import-untyped]
+
+        return __version__
+    except ModuleNotFoundError:
+        return "N/A"
+
+
+def _resolve_requests_version() -> str:
+    try:
+        from requests import __version__
+
+        return __version__
+    except ModuleNotFoundError:
+        return "N/A"
+
+
+def _resolve_requests_cache_version() -> str:
+    try:
+        from requests_cache import __version__
+
+        return __version__
+    except ModuleNotFoundError:
+        return "N/A"
+
+
+def _resolve_teletype_version() -> str:
+    try:
+        from teletype import VERSION
+
+        return VERSION
+    except ModuleNotFoundError:
+        return "N/A"
+
+
+VERSION: str = _resolve_version()
+appdirs_version: str = _resolve_appdirs_version()
+cache_dir: str = _resolve_cache_dir()
+guessit_version: str = _resolve_guessit_version()
+requests_version: str = _resolve_requests_version()
+requests_cache_version: str = _resolve_requests_cache_version()
+teletype_version: str = _resolve_teletype_version()
 
 
 CACHE_PATH = Path(

--- a/mnamer/endpoints.py
+++ b/mnamer/endpoints.py
@@ -1,8 +1,15 @@
-"""Provides a low-level interface for metadata media APIs."""
+"""Provides a low-level interface for metadata media APIs.
+
+Endpoint functions raise exceptions on API errors, so the response TypedDicts in this module
+describe the success-case shape only. Keys are snake_case. Responses are routed through
+`normalize_keys` to translate API camelCase/PascalCase before cast. Fields documented as
+always-present per the API contract are required; partial/optional fields use `NotRequired`.
+"""
 
 import datetime
 from re import match
 from time import sleep
+from typing import Any, NotRequired, TypedDict, cast
 
 from mnamer.exceptions import (
     MnamerException,
@@ -10,10 +17,109 @@ from mnamer.exceptions import (
     MnamerNotFoundException,
 )
 from mnamer.language import Language
-from mnamer.utils import clean_dict, parse_date, request_json
+from mnamer.utils import clean_dict, normalize_keys, parse_date, request_json
 
 OMDB_PLOT_TYPES = {"short", "long"}
 MAX_RETRIES = 5
+
+
+class OmdbSearchEntry(TypedDict):
+    imdb_id: str
+    year: str
+    title: NotRequired[str]
+
+
+class OmdbTitleResponse(TypedDict):
+    title: str
+    year: str
+    released: NotRequired[str]
+    plot: NotRequired[str]
+    imdb_id: str
+    error: NotRequired[str]
+
+
+class OmdbSearchResponse(TypedDict):
+    search: list[OmdbSearchEntry]
+    total_results: NotRequired[str]
+    error: NotRequired[str]
+
+
+class TmdbSearchEntry(TypedDict):
+    id: int
+    title: str
+    release_date: NotRequired[str]
+    overview: NotRequired[str]
+
+
+class TmdbMovieResponse(TypedDict):
+    id: int
+    title: str
+    release_date: NotRequired[str]
+    overview: NotRequired[str]
+    imdb_id: NotRequired[str]
+
+
+class TmdbSearchResponse(TypedDict):
+    results: list[TmdbSearchEntry]
+    total_pages: int
+    total_results: int
+
+
+class TvdbLinks(TypedDict):
+    last: int
+
+
+class TvdbSeriesData(TypedDict):
+    id: int
+    series_name: str
+
+
+class TvdbSeriesResponse(TypedDict):
+    data: TvdbSeriesData
+
+
+class TvdbEpisodeEntry(TypedDict):
+    first_aired: str
+    aired_episode_number: int
+    aired_season: int
+    overview: str | None
+    episode_name: str
+
+
+class TvdbEpisodesResponse(TypedDict):
+    data: list[TvdbEpisodeEntry]
+    links: TvdbLinks
+
+
+class TvdbSearchEntry(TypedDict):
+    id: int
+
+
+class TvdbSearchResponse(TypedDict):
+    data: list[TvdbSearchEntry]
+
+
+class TvMazeExternals(TypedDict):
+    thetvdb: int | str | None
+    imdb: NotRequired[str | None]
+
+
+class TvMazeShow(TypedDict):
+    id: int
+    name: str
+    externals: TvMazeExternals
+
+
+class TvMazeSearchEntry(TypedDict):
+    show: TvMazeShow
+
+
+class TvMazeEpisode(TypedDict):
+    airdate: str | None
+    number: int | None
+    season: int
+    name: str | None
+    summary: str | None
 
 
 def omdb_title(
@@ -26,7 +132,7 @@ def omdb_title(
     year: int | None = None,
     plot: str | None = None,
     cache: bool = True,
-) -> dict:
+) -> OmdbTitleResponse:
     """
     Looks up media by id using the Open Movie Database.
 
@@ -37,7 +143,7 @@ def omdb_title(
     elif plot and plot not in OMDB_PLOT_TYPES:
         raise MnamerException(f"plot must be one of {','.join(OMDB_PLOT_TYPES)}")
     url = "http://www.omdbapi.com"
-    parameters = {
+    parameters: dict[str, Any] = {
         "apikey": api_key,
         "i": id_imdb,
         "t": title,
@@ -47,18 +153,18 @@ def omdb_title(
         "type": media,
         "plot": plot,
     }
-    parameters = clean_dict(parameters)
-    status, content = request_json(url, parameters, cache=cache)
-    error = content.get("Error") if isinstance(content, dict) else None
+    status, content = request_json(url, clean_dict(parameters), cache=cache)
+    content = normalize_keys(content)
+    error = content.get("error")
     if status == 401:
         if error == "Request limit reached!":
             raise MnamerException("API request limit reached")
         raise MnamerException("invalid API key")
-    elif status != 200 or not isinstance(content, dict):  # pragma: no cover
+    elif status != 200 or not content:  # pragma: no cover
         raise MnamerNetworkException("OMDb down or unavailable?")
     elif error:
         raise MnamerNotFoundException(error)
-    return content
+    return cast(OmdbTitleResponse, content)
 
 
 def omdb_search(
@@ -68,7 +174,7 @@ def omdb_search(
     media: str | None = None,
     page: int = 1,
     cache: bool = True,
-) -> dict:
+) -> OmdbSearchResponse:
     """
     Search for media using the Open Movie Database.
 
@@ -77,22 +183,22 @@ def omdb_search(
     if page < 1 or page > 100:
         raise MnamerException("page must be between 1 and 100")
     url = "http://www.omdbapi.com"
-    parameters = {
+    parameters: dict[str, Any] = {
         "apikey": api_key,
         "s": query,
         "y": year,
         "type": media,
         "page": page,
     }
-    parameters = clean_dict(parameters)
-    status, content = request_json(url, parameters, cache=cache)
+    status, content = request_json(url, clean_dict(parameters), cache=cache)
+    content = normalize_keys(content)
     if status == 401:
         raise MnamerException("invalid API key")
-    elif content and not content.get("totalResults"):
+    elif content and not content.get("total_results"):
         raise MnamerNotFoundException()
     elif not content or status != 200:  # pragma: no cover
         raise MnamerNetworkException("OMDb down or unavailable?")
-    return content
+    return cast(OmdbSearchResponse, content)
 
 
 def tmdb_find(
@@ -101,7 +207,7 @@ def tmdb_find(
     external_id: str,
     language: Language | None = None,
     cache: bool = True,
-) -> dict:
+) -> dict[str, Any]:
     """
     Search for The Movie Database objects using another DB's foreign key.
 
@@ -117,7 +223,7 @@ def tmdb_find(
     if external_source == "imdb_id" and not match(r"tt\d+", external_id):
         raise MnamerException("invalid imdb tt-const value")
     url = "https://api.themoviedb.org/3/find/" + external_id or ""
-    parameters = {
+    parameters: dict[str, Any] = {
         "api_key": api_key,
         "external_source": external_source,
         "language": language,
@@ -130,11 +236,12 @@ def tmdb_find(
         "tv_season_results",
     ]
     status, content = request_json(url, parameters, cache=cache)
+    content = normalize_keys(content)
     if status == 401:
         raise MnamerException("invalid API key")
     elif status != 200 or not any(content.keys()):  # pragma: no cover
         raise MnamerNetworkException("TMDb down or unavailable?")
-    elif status == 404 or not any(content.get(k, {}) for k in keys):
+    elif not any(content.get(k, {}) for k in keys):
         raise MnamerNotFoundException
     return content
 
@@ -144,22 +251,23 @@ def tmdb_movies(
     id_tmdb: str,
     language: Language | None = None,
     cache: bool = True,
-) -> dict:
+) -> TmdbMovieResponse:
     """
     Lookup a movie item using The Movie Database.
 
     Online docs: developers.themoviedb.org/3/movies.
     """
     url = f"https://api.themoviedb.org/3/movie/{id_tmdb}"
-    parameters = {"api_key": api_key, "language": language}
+    parameters: dict[str, Any] = {"api_key": api_key, "language": language}
     status, content = request_json(url, parameters, cache=cache)
+    content = normalize_keys(content)
     if status == 401:
         raise MnamerException("invalid API key")
     elif status == 404:
         raise MnamerNotFoundException
     elif status != 200 or not any(content.keys()):  # pragma: no cover
         raise MnamerNetworkException("TMDb down or unavailable?")
-    return content
+    return cast(TmdbMovieResponse, content)
 
 
 def tmdb_search_movies(
@@ -171,14 +279,14 @@ def tmdb_search_movies(
     adult: bool = False,
     page: int = 1,
     cache: bool = True,
-) -> dict:
+) -> TmdbSearchResponse:
     """
     Search for movies using The Movie Database.
 
     Online docs: developers.themoviedb.org/3/search/search-movies.
     """
     url = "https://api.themoviedb.org/3/search/movie"
-    parameters = {
+    parameters: dict[str, Any] = {
         "api_key": api_key,
         "query": title,
         "page": page,
@@ -188,16 +296,17 @@ def tmdb_search_movies(
         "year": year,
     }
     status, content = request_json(url, parameters, cache=cache)
+    content = normalize_keys(content)
     if status == 401:
         raise MnamerException("invalid API key")
     elif status != 200 or not any(content.keys()):  # pragma: no cover
         raise MnamerNetworkException("TMDb down or unavailable?")
-    elif status == 404 or status == 422 or not content.get("total_results"):
+    elif not content.get("total_results"):
         raise MnamerNotFoundException
-    return content
+    return cast(TmdbSearchResponse, content)
 
 
-def tvdb_login(api_key: str | None) -> str:
+def tvdb_login(api_key: str) -> str:
     """
     Logs into TVDb using the provided api key.
 
@@ -235,7 +344,7 @@ def tvdb_episodes_id(
     id_tvdb: str,
     language: Language | None = None,
     cache: bool = True,
-) -> dict:
+) -> dict[str, Any]:
     """
     Returns the full information for a given episode id.
 
@@ -249,6 +358,7 @@ def tvdb_episodes_id(
     status, content = request_json(
         url, headers=headers, cache=cache is True and language is None
     )
+    content = normalize_keys(content)
     if status == 401:
         raise MnamerException("invalid token")
     elif status == 404 or not content.get("data"):
@@ -265,7 +375,7 @@ def tvdb_series_id(
     id_tvdb: str,
     language: Language | None = None,
     cache: bool = True,
-) -> dict:
+) -> TvdbSeriesResponse:
     """
     Returns a series records that contains all information known about a
     particular series id.
@@ -280,6 +390,7 @@ def tvdb_series_id(
     status, content = request_json(
         url, headers=headers, cache=cache is True and language is None
     )
+    content = normalize_keys(content)
     if status == 401:
         raise MnamerException("invalid token")
     elif status == 404 or not content.get("data"):
@@ -288,7 +399,7 @@ def tvdb_series_id(
         raise MnamerNetworkException("TVDb down or unavailable?")
     elif content["data"]["id"] == 0:
         raise MnamerNotFoundException
-    return content
+    return cast(TvdbSeriesResponse, content)
 
 
 def tvdb_series_id_episodes(
@@ -297,7 +408,7 @@ def tvdb_series_id_episodes(
     page: int = 1,
     language: Language | None = None,
     cache: bool = True,
-) -> dict:
+) -> TvdbEpisodesResponse:
     """
     All episodes for a given series.
 
@@ -309,17 +420,18 @@ def tvdb_series_id_episodes(
     headers = {"Authorization": f"Bearer {token}"}
     if language:
         headers["Accept-Language"] = language.a2
-    parameters = {"page": page}
+    parameters: dict[str, Any] = {"page": page}
     status, content = request_json(
         url, parameters, headers=headers, cache=cache is True and language is None
     )
+    content = normalize_keys(content)
     if status == 401:
         raise MnamerException("invalid token")
     elif status == 404 or not content.get("data"):
         raise MnamerNotFoundException
     elif status != 200:  # pragma: no cover
         raise MnamerNetworkException("TVDb down or unavailable?")
-    return content
+    return cast(TvdbEpisodesResponse, content)
 
 
 def tvdb_series_id_episodes_query(
@@ -330,7 +442,7 @@ def tvdb_series_id_episodes_query(
     page: int = 1,
     language: Language | None = None,
     cache: bool = True,
-) -> dict:
+) -> TvdbEpisodesResponse:
     """
     Allows the user to query against episodes for the given series.
 
@@ -343,20 +455,25 @@ def tvdb_series_id_episodes_query(
     headers = {"Authorization": f"Bearer {token}"}
     if language:
         headers["Accept-Language"] = language.a2
-    parameters = {"airedSeason": season, "airedEpisode": episode, "page": page}
+    parameters: dict[str, Any] = {
+        "airedSeason": season,
+        "airedEpisode": episode,
+        "page": page,
+    }
     status, content = request_json(
         url,
         parameters,
         headers=headers,
         cache=cache is True and language is None,
     )
+    content = normalize_keys(content)
     if status == 401:
         raise MnamerException("invalid token")
     elif status == 404 or not content.get("data"):
         raise MnamerNotFoundException
     elif status != 200:  # pragma: no cover
         raise MnamerNetworkException("TVDb down or unavailable?")
-    return content
+    return cast(TvdbEpisodesResponse, content)
 
 
 def tvdb_search_series(
@@ -366,7 +483,7 @@ def tvdb_search_series(
     id_zap2it: str | None = None,
     language: Language | None = None,
     cache: bool = True,
-) -> dict:
+) -> TvdbSearchResponse:
     """
     Allows the user to search for a series based on the following parameters.
 
@@ -375,13 +492,18 @@ def tvdb_search_series(
     """
     Language.ensure_valid_for_tvdb(language)
     url = "https://api.thetvdb.com/search/series"
-    parameters = {"name": series, "imdbId": id_imdb, "zap2itId": id_zap2it}
+    parameters: dict[str, Any] = {
+        "name": series,
+        "imdbId": id_imdb,
+        "zap2itId": id_zap2it,
+    }
     headers = {"Authorization": f"Bearer {token}"}
     if language:
         headers["Accept-Language"] = language.a2
     status, content = request_json(
         url, parameters, headers=headers, cache=cache is True and language is None
     )
+    content = normalize_keys(content)
     if status == 401:
         raise MnamerException("invalid token")
     elif status == 405:
@@ -392,7 +514,7 @@ def tvdb_search_series(
         raise MnamerNotFoundException
     elif status != 200:  # pragma: no cover
         raise MnamerNetworkException("TVDb down or unavailable?")
-    return content
+    return cast(TvdbSearchResponse, content)
 
 
 def tvmaze_show(
@@ -400,14 +522,14 @@ def tvmaze_show(
     embed_episodes: bool = False,
     cache: bool = False,
     attempt: int = 1,
-):
+) -> TvMazeShow:
     """
     Retrieve all primary information for a given show.
 
     Online docs: https://www.tvmaze.com/api#show-main-information
     """
     url = f"http://api.tvmaze.com/shows/{id_tvmaze}"
-    parameters = {}
+    parameters: dict[str, Any] = {}
     if embed_episodes:
         parameters["embed"] = "episodes"
     status, content = request_json(url, parameters, cache=cache)
@@ -418,10 +540,12 @@ def tvmaze_show(
         raise MnamerNotFoundException
     elif status != 200:  # pragma: no cover
         raise MnamerNetworkException
-    return content
+    return cast(TvMazeShow, normalize_keys(content))
 
 
-def tvmaze_show_search(query: str, cache: bool = True, attempt: int = 1) -> dict:
+def tvmaze_show_search(
+    query: str, cache: bool = True, attempt: int = 1
+) -> list[TvMazeSearchEntry]:
     """
     Search through all the shows in the database by the show's name. A fuzzy
     algorithm is used (with a fuzziness value of 2), meaning that shows will be
@@ -431,7 +555,7 @@ def tvmaze_show_search(query: str, cache: bool = True, attempt: int = 1) -> dict
     Online docs: https://www.tvmaze.com/api#show-search
     """
     url = "http://api.tvmaze.com/search/shows"
-    parameters = {"q": query}
+    parameters: dict[str, Any] = {"q": query}
     status, content = request_json(url, parameters, cache=cache)
     if status == 443 and attempt <= MAX_RETRIES:  # pragma: no cover
         sleep(attempt * 2)
@@ -440,10 +564,12 @@ def tvmaze_show_search(query: str, cache: bool = True, attempt: int = 1) -> dict
         raise MnamerNotFoundException
     elif status != 200:  # pragma: no cover
         raise MnamerNetworkException
-    return content
+    return cast(list[TvMazeSearchEntry], normalize_keys(content))
 
 
-def tvmaze_show_single_search(query: str, cache: bool = True, attempt: int = 1) -> dict:
+def tvmaze_show_single_search(
+    query: str, cache: bool = True, attempt: int = 1
+) -> TvMazeShow:
     """
     Singlesearch endpoint either returns exactly one result, or no result at
     all. This endpoint is also forgiving of typos, but less so than the regular
@@ -453,7 +579,7 @@ def tvmaze_show_single_search(query: str, cache: bool = True, attempt: int = 1) 
     Online docs: https://www.tvmaze.com/api#show-single-search
     """
     url = "http://api.tvmaze.com/singlesearch/shows"
-    parameters = {"q": query}
+    parameters: dict[str, Any] = {"q": query}
     status, content = request_json(url, parameters, cache=cache)
     if status == 443 and attempt <= MAX_RETRIES:  # pragma: no cover
         sleep(attempt * 2)
@@ -462,7 +588,7 @@ def tvmaze_show_single_search(query: str, cache: bool = True, attempt: int = 1) 
         raise MnamerNotFoundException
     elif status != 200:  # pragma: no cover
         raise MnamerNetworkException
-    return content
+    return cast(TvMazeShow, normalize_keys(content))
 
 
 def tvmaze_show_lookup(
@@ -470,7 +596,7 @@ def tvmaze_show_lookup(
     id_tvdb: str | None = None,
     cache: bool = True,
     attempt: int = 1,
-) -> dict:
+) -> TvMazeShow:
     """
     If you already know a show's tvrage, thetvdb or IMDB ID, you can use this
     endpoint to find this exact show on TVmaze.
@@ -480,7 +606,7 @@ def tvmaze_show_lookup(
     if not [id_imdb, id_tvdb].count(None) == 1:
         raise MnamerException("id_imdb and id_tvdb are mutually exclusive")
     url = "http://api.tvmaze.com/lookup/shows"
-    parameters = {"imdb": id_imdb, "thetvdb": id_tvdb}
+    parameters: dict[str, Any] = {"imdb": id_imdb, "thetvdb": id_tvdb}
     status, content = request_json(url, parameters, cache=cache)
     if status == 443 and attempt <= MAX_RETRIES:  # pragma: no cover
         sleep(attempt * 2)
@@ -489,7 +615,7 @@ def tvmaze_show_lookup(
         raise MnamerNotFoundException
     elif status != 200 or not content:  # pragma: no cover
         raise MnamerNetworkException
-    return content
+    return cast(TvMazeShow, normalize_keys(content))
 
 
 def tvmaze_show_episodes_list(
@@ -497,7 +623,7 @@ def tvmaze_show_episodes_list(
     include_specials: bool = False,
     cache: bool = True,
     attempt: int = 1,
-) -> dict:
+) -> list[TvMazeEpisode]:
     """
     A complete list of episodes for the given show. Episodes are returned in
     their airing order, and include full episode information. By default,
@@ -506,7 +632,7 @@ def tvmaze_show_episodes_list(
     Online docs: https://www.tvmaze.com/api#show-episode-list
     """
     url = f"http://api.tvmaze.com/shows/{id_tvmaze}/episodes"
-    parameters = {"specials": int(include_specials)}
+    parameters: dict[str, Any] = {"specials": int(include_specials)}
     status, content = request_json(url, parameters, cache=cache)
     if status == 443 and attempt <= MAX_RETRIES:  # pragma: no cover
         sleep(attempt * 2)
@@ -517,7 +643,7 @@ def tvmaze_show_episodes_list(
         raise MnamerNotFoundException
     elif status != 200 or not content:  # pragma: no cover
         raise MnamerNetworkException
-    return content
+    return cast(list[TvMazeEpisode], normalize_keys(content))
 
 
 def tvmaze_episodes_by_date(
@@ -525,7 +651,7 @@ def tvmaze_episodes_by_date(
     air_date: datetime.date | str,
     cache: bool = True,
     attempt: int = 1,
-) -> dict:
+) -> list[TvMazeEpisode]:
     """
     Retrieves all episodes from this show that have aired on a specific date.
     Useful for daily shows that don't adhere to a common season numbering.
@@ -533,7 +659,7 @@ def tvmaze_episodes_by_date(
     Online docs: https://www.tvmaze.com/api#episodes-by-date
     """
     url = f"http://api.tvmaze.com/shows/{id_tvmaze}/episodesbydate"
-    parameters = {"date": parse_date(air_date)}
+    parameters: dict[str, Any] = {"date": parse_date(air_date)}
     status, content = request_json(url, parameters, cache=cache)
     if status == 443 and attempt <= MAX_RETRIES:  # pragma: no cover
         sleep(attempt * 2)
@@ -542,7 +668,7 @@ def tvmaze_episodes_by_date(
         raise MnamerNotFoundException
     elif status != 200 or not content:  # pragma: no cover
         raise MnamerNetworkException
-    return content
+    return cast(list[TvMazeEpisode], normalize_keys(content))
 
 
 def tvmaze_episode_by_number(
@@ -551,7 +677,7 @@ def tvmaze_episode_by_number(
     episode: int | None,
     cache: bool = True,
     attempt: int = 1,
-) -> dict:
+) -> TvMazeEpisode:
     """
     Retrieve one specific episode from this show given its season number and
     episode number.
@@ -559,7 +685,7 @@ def tvmaze_episode_by_number(
     Online docs: https://www.tvmaze.com/api#episode-by-number
     """
     url = f"http://api.tvmaze.com/shows/{id_tvmaze}/episodebynumber"
-    parameters = {"season": season, "number": episode}
+    parameters: dict[str, Any] = {"season": season, "number": episode}
     status, content = request_json(url, parameters, cache=cache)
     if status == 443 and attempt <= MAX_RETRIES:  # pragma: no cover
         sleep(attempt * 2)
@@ -568,4 +694,4 @@ def tvmaze_episode_by_number(
         raise MnamerNotFoundException
     elif status != 200 or not content:  # pragma: no cover
         raise MnamerNetworkException
-    return content
+    return cast(TvMazeEpisode, normalize_keys(content))

--- a/mnamer/frontends.py
+++ b/mnamer/frontends.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import override
 
 from mnamer import tty
 from mnamer.const import SYSTEM, USAGE, VERSION
@@ -64,6 +65,8 @@ class Frontend(ABC):
 
 
 class Cli(Frontend):
+    success_count: int
+
     def __init__(self, settings: SettingStore):
         super().__init__(settings)
         if not settings.targets:
@@ -75,6 +78,7 @@ class Cli(Frontend):
     def total_count(self):
         return len(self.targets)
 
+    @override
     def launch(self) -> None:
         tty.msg("Starting mnamer", MessageType.HEADING)
         self._ensure_targets()
@@ -201,5 +205,6 @@ class Cli(Frontend):
 
 
 class Gui(Frontend):
+    @override
     def launch(self):
         pass  # to be implemented in v3

--- a/mnamer/language.py
+++ b/mnamer/language.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Any
+from typing import Any, Self, override
 
 from mnamer.exceptions import MnamerException
 
@@ -41,7 +41,7 @@ class Language:
     a3: str
 
     @classmethod
-    def parse(cls, value: Any) -> Language | None:
+    def parse(cls, value: Any) -> Self | None:
         if not value:
             return None
         if isinstance(value, cls):
@@ -63,11 +63,12 @@ class Language:
         raise MnamerException("Could not determine language")
 
     @classmethod
-    def all(cls) -> tuple[Language, ...]:
+    def all(cls) -> tuple[Self, ...]:
         return tuple(
             cls(row[0].capitalize(), row[1], row[2]) for row in KNOWN_LANGUAGES
         )
 
+    @override
     def __str__(self) -> str:
         return self.a2
 

--- a/mnamer/metadata.py
+++ b/mnamer/metadata.py
@@ -5,7 +5,7 @@ import datetime as dt
 import re
 from collections.abc import Callable, Mapping, Sequence
 from string import Formatter
-from typing import Any
+from typing import Any, override
 
 from mnamer.language import Language
 from mnamer.types import MediaType
@@ -22,9 +22,11 @@ from mnamer.utils import (
 
 
 class _MetaFormatter(Formatter):
+    @override
     def format_field(self, value: None | int | str, format_spec: str) -> str:
         return format(value, format_spec) if value is not None else ""
 
+    @override
     def get_value(
         self, key: str | int, args: Sequence[Any], kwargs: Mapping[str, Any]
     ) -> None | int | str:
@@ -55,8 +57,9 @@ class Metadata:
         else:
             raise ValueError(f"Unknown metadata class: {cls}")
 
+    @override
     def __setattr__(self, key: str, value: Any):
-        converter_map: dict[str, Callable] = {
+        converter_map: dict[str, Callable[[Any], Any]] = {
             "container": normalize_container,
             "group": str.upper,
             "language": Language.parse,
@@ -65,14 +68,16 @@ class Metadata:
             "quality": str.lower,
             "synopsis": str.capitalize,
         }
-        converter: Callable | None = converter_map.get(key)
+        converter: Callable[[Any], Any] | None = converter_map.get(key)
         if value is not None and converter:
             value = converter(value)
         super().__setattr__(key, value)
 
-    def __format__(self, format_spec: str | None):
+    @override
+    def __format__(self, format_spec: str | None) -> str:
         raise NotImplementedError
 
+    @override
     def __str__(self) -> str:
         return self.__format__(None)
 
@@ -88,7 +93,7 @@ class Metadata:
         d["extension"] = self.extension
         return d
 
-    def _format_repl(self, mobj) -> str:
+    def _format_repl(self, mobj: re.Match[str]) -> str:
         format_string, key = mobj.groups()
         value = _MetaFormatter().vformat(format_string, "", self.as_dict())
         if key in {"name", "series", "synopsis", "title"}:
@@ -116,19 +121,21 @@ class MetadataMovie(Metadata):
     id_imdb: str | None = None
     id_tmdb: str | None = None
 
-    def __format__(self, format_spec: str | None):
+    @override
+    def __format__(self, format_spec: str | None) -> str:
         default = "{name} ({year})"
         re_pattern = r"({(\w+)(?:\[[\w:]+\])?(?:\:\d{1,2})?})"
         s = re.sub(re_pattern, self._format_repl, format_spec or default)
         s = str_fix_padding(s)
         return s
 
+    @override
     def __setattr__(self, key: str, value: Any):
-        converter_map: dict[str, Callable] = {
+        converter_map: dict[str, Callable[[Any], Any]] = {
             "name": fn_pipe(str_replace_slashes, str_title_case),
             "year": year_parse,
         }
-        converter: Callable | None = converter_map.get(key)
+        converter: Callable[[Any], Any] | None = converter_map.get(key)
         if value is not None and converter:
             value = converter(value)
         super().__setattr__(key, value)
@@ -157,22 +164,24 @@ class MetadataEpisode(Metadata):
         if isinstance(self.date, str):
             self.date = parse_date(self.date)
 
-    def __format__(self, format_spec: str | None):
+    @override
+    def __format__(self, format_spec: str | None) -> str:
         default = "{series} - {season:02}x{episode:02} - {title}"
         re_pattern = r"({(\w+)(?:\[[\w:]+\])?(?:\:\d{1,2})?})"
         s = re.sub(re_pattern, self._format_repl, format_spec or default)
         s = str_fix_padding(s)
         return s
 
+    @override
     def __setattr__(self, key: str, value: Any):
-        converter_map: dict[str, Callable] = {
+        converter_map: dict[str, Callable[[Any], Any]] = {
             "date": parse_date,
             "episode": int,
             "season": int,
             "series": fn_pipe(str_replace_slashes, str_title_case),
             "title": fn_pipe(str_replace_slashes, str_title_case),
         }
-        converter: Callable | None = converter_map.get(key)
+        converter: Callable[[Any], Any] | None = converter_map.get(key)
         if value is not None and converter:
             value = converter(value)
         super().__setattr__(key, value)

--- a/mnamer/providers.py
+++ b/mnamer/providers.py
@@ -37,10 +37,10 @@ from mnamer.utils import parse_date, year_range_parse
 class Provider[M: Metadata](ABC):
     """ABC for Providers, high-level interfaces for metadata media providers."""
 
-    api_key: str | None = None
+    api_key: str
     cache: bool = True
 
-    def __init__(self, api_key: str | None = None, cache: bool = True):
+    def __init__(self, api_key: str = "", cache: bool = True):
         """Initializes the provider."""
         if api_key:
             self.api_key = api_key
@@ -79,28 +79,33 @@ class Provider[M: Metadata](ABC):
     def provider_factory(
         provider: Literal[ProviderType.TVMAZE], settings: SettingStore
     ) -> TvMaze: ...
+    @overload
+    @staticmethod
+    def provider_factory(
+        provider: ProviderType, settings: SettingStore
+    ) -> Omdb | Tmdb | Tvdb | TvMaze: ...
     @staticmethod
     def provider_factory(
         provider: ProviderType, settings: SettingStore
     ) -> Omdb | Tmdb | Tvdb | TvMaze:
         """Factory function for DB Provider concrete classes."""
-        provider_cls: type[Omdb] | type[Tmdb] | type[Tvdb] | type[TvMaze] = {
+        provider_classes: dict[
+            ProviderType, type[Omdb] | type[Tmdb] | type[Tvdb] | type[TvMaze]
+        ] = {
             ProviderType.TMDB: Tmdb,
             ProviderType.TVDB: Tvdb,
             ProviderType.TVMAZE: TvMaze,
             ProviderType.OMDB: Omdb,
-        }[provider]
-        return provider_cls.from_settings(settings)
+        }
+        return provider_classes[provider].from_settings(settings)
 
 
 class Omdb(Provider[MetadataMovie]):
     """Queries the OMDb API."""
 
-    # str | None (not str) for Liskov compatibility with the Provider base; runtime
-    # value is always str because environ.get supplies the default.
-    api_key: str | None = environ.get("API_KEY_OMDB", "477a7ebc")
+    api_key: str = environ.get("API_KEY_OMDB", "477a7ebc")
 
-    def __init__(self, api_key: str | None = None, cache: bool = True):
+    def __init__(self, api_key: str = "", cache: bool = True):
         super().__init__(api_key, cache)
         assert self.api_key
 
@@ -171,11 +176,9 @@ class Omdb(Provider[MetadataMovie]):
 class Tmdb(Provider[MetadataMovie]):
     """Queries the TMDb API."""
 
-    api_key: str | None = environ.get(
-        "API_KEY_TMDB", "db972a607f2760bb19ff8bb34074b4c7"
-    )
+    api_key: str = environ.get("API_KEY_TMDB", "db972a607f2760bb19ff8bb34074b4c7")
 
-    def __init__(self, api_key: str | None = None, cache: bool = True):
+    def __init__(self, api_key: str = "", cache: bool = True):
         super().__init__(api_key, cache)
         assert self.api_key
 
@@ -248,10 +251,10 @@ class Tmdb(Provider[MetadataMovie]):
 class Tvdb(Provider[MetadataEpisode]):
     """Queries the TVDb API."""
 
-    api_key: str | None = environ.get("API_KEY_TVDB", "E69C7A2CEF2F3152")
+    api_key: str = environ.get("API_KEY_TVDB", "E69C7A2CEF2F3152")
     token: str
 
-    def __init__(self, api_key: str | None = None, cache: bool = True):
+    def __init__(self, api_key: str = "", cache: bool = True):
         super().__init__(api_key, cache)
         assert self.api_key
         self.token = "" if self.cache else self._login()
@@ -385,9 +388,7 @@ class Tvdb(Provider[MetadataEpisode]):
 class TvMaze(Provider[MetadataEpisode]):
     """Queries the TVMaze API."""
 
-    api_key: str | None = environ.get(
-        "API_KEY_TVMAZE", "wxadpr5W7yWma_QYaHM4BB_l80WIIjcK"
-    )
+    api_key: str = environ.get("API_KEY_TVMAZE", "wxadpr5W7yWma_QYaHM4BB_l80WIIjcK")
 
     @override
     def search(self, query: MetadataEpisode) -> Iterator[MetadataEpisode]:

--- a/mnamer/providers.py
+++ b/mnamer/providers.py
@@ -6,8 +6,11 @@ import datetime as dt
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from os import environ
+from typing import Literal, Self, overload, override
 
 from mnamer.endpoints import (
+    TvMazeEpisode,
+    TvMazeShow,
     omdb_search,
     omdb_title,
     tmdb_movies,
@@ -31,7 +34,7 @@ from mnamer.types import MediaType, ProviderType
 from mnamer.utils import parse_date, year_range_parse
 
 
-class Provider(ABC):
+class Provider[M: Metadata](ABC):
     """ABC for Providers, high-level interfaces for metadata media providers."""
 
     api_key: str | None = None
@@ -45,7 +48,7 @@ class Provider(ABC):
             self.cache = cache
 
     @classmethod
-    def from_settings(cls, settings: SettingStore):
+    def from_settings(cls, settings: SettingStore) -> Self:
         assert settings
         api_field = f"api_key_{cls.__name__.lower()}"
         api_key = getattr(settings, api_field)
@@ -53,13 +56,35 @@ class Provider(ABC):
         return cls(api_key, cache)
 
     @abstractmethod
-    def search(self, query) -> Iterator[Metadata]:
+    def search(self, query: M) -> Iterator[M]:
         pass
 
+    @overload
     @staticmethod
-    def provider_factory(provider: ProviderType, settings: SettingStore) -> Provider:
+    def provider_factory(
+        provider: Literal[ProviderType.OMDB], settings: SettingStore
+    ) -> Omdb: ...
+    @overload
+    @staticmethod
+    def provider_factory(
+        provider: Literal[ProviderType.TMDB], settings: SettingStore
+    ) -> Tmdb: ...
+    @overload
+    @staticmethod
+    def provider_factory(
+        provider: Literal[ProviderType.TVDB], settings: SettingStore
+    ) -> Tvdb: ...
+    @overload
+    @staticmethod
+    def provider_factory(
+        provider: Literal[ProviderType.TVMAZE], settings: SettingStore
+    ) -> TvMaze: ...
+    @staticmethod
+    def provider_factory(
+        provider: ProviderType, settings: SettingStore
+    ) -> Omdb | Tmdb | Tvdb | TvMaze:
         """Factory function for DB Provider concrete classes."""
-        provider_cls = {
+        provider_cls: type[Omdb] | type[Tmdb] | type[Tvdb] | type[TvMaze] = {
             ProviderType.TMDB: Tmdb,
             ProviderType.TVDB: Tvdb,
             ProviderType.TVMAZE: TvMaze,
@@ -68,15 +93,18 @@ class Provider(ABC):
         return provider_cls.from_settings(settings)
 
 
-class Omdb(Provider):
+class Omdb(Provider[MetadataMovie]):
     """Queries the OMDb API."""
 
-    api_key: str = environ.get("API_KEY_OMDB", "477a7ebc")
+    # str | None (not str) for Liskov compatibility with the Provider base; runtime
+    # value is always str because environ.get supplies the default.
+    api_key: str | None = environ.get("API_KEY_OMDB", "477a7ebc")
 
     def __init__(self, api_key: str | None = None, cache: bool = True):
         super().__init__(api_key, cache)
         assert self.api_key
 
+    @override
     def search(self, query: MetadataMovie) -> Iterator[MetadataMovie]:
         """Searches OMDb for movie metadata."""
         assert query
@@ -91,20 +119,22 @@ class Omdb(Provider):
     def _lookup_movie(self, id_imdb: str) -> Iterator[MetadataMovie]:
         assert self.api_key
         response = omdb_title(self.api_key, id_imdb, cache=self.cache)
+        released = response.get("released")
         try:
-            release_date = dt.datetime.strptime(
-                response["Released"], "%d %b %Y"
-            ).strftime("%Y-%m-%d")
-        except (KeyError, ValueError):
-            if response.get("Year") in (None, "N/A"):
+            assert released
+            release_date = dt.datetime.strptime(released, "%d %b %Y").strftime(
+                "%Y-%m-%d"
+            )
+        except (AssertionError, ValueError):
+            if response.get("year") in (None, "N/A"):
                 release_date = None
             else:
-                release_date = "{}-01-01".format(response["Year"])
+                release_date = "{}-01-01".format(response["year"])
         meta = MetadataMovie(
-            name=response["Title"],
+            name=response["title"],
             year=release_date,
-            synopsis=response["Plot"],
-            id_imdb=response["imdbID"],
+            synopsis=response.get("plot"),
+            id_imdb=response["imdb_id"],
         )
         if meta.synopsis == "N/A":
             meta.synopsis = None
@@ -127,9 +157,9 @@ class Omdb(Provider):
                 )
             except MnamerNotFoundException:
                 break
-            for entry in response["Search"]:
-                if year_from <= int(entry["Year"]) <= year_to:
-                    yield from self._lookup_movie(entry["imdbID"])
+            for entry in response["search"]:
+                if year_from <= int(entry["year"]) <= year_to:
+                    yield from self._lookup_movie(entry["imdb_id"])
                     found = True
             if page >= page_max:
                 break
@@ -138,15 +168,18 @@ class Omdb(Provider):
             raise MnamerNotFoundException
 
 
-class Tmdb(Provider):
+class Tmdb(Provider[MetadataMovie]):
     """Queries the TMDb API."""
 
-    api_key: str = environ.get("API_KEY_TMDB", "db972a607f2760bb19ff8bb34074b4c7")
+    api_key: str | None = environ.get(
+        "API_KEY_TMDB", "db972a607f2760bb19ff8bb34074b4c7"
+    )
 
     def __init__(self, api_key: str | None = None, cache: bool = True):
         super().__init__(api_key, cache)
         assert self.api_key
 
+    @override
     def search(self, query: MetadataMovie) -> Iterator[MetadataMovie]:
         """Searches TMDb for movie metadata."""
         assert query
@@ -166,13 +199,15 @@ class Tmdb(Provider):
         yield MetadataMovie(
             name=response["title"],
             language=language,
-            year=response["release_date"],
-            synopsis=response["overview"],
-            id_tmdb=response["id"],
-            id_imdb=response["imdb_id"],
+            year=response.get("release_date"),
+            synopsis=response.get("overview"),
+            id_tmdb=str(response["id"]),
+            id_imdb=response.get("imdb_id"),
         )
 
-    def _search_name(self, name: str, year: str | None, language: Language | None):
+    def _search_name(
+        self, name: str, year: str | None, language: Language | None
+    ) -> Iterator[MetadataMovie]:
         assert self.api_key
         page = 1
         page_max = 5  # each page yields a maximum of 20 results
@@ -189,11 +224,11 @@ class Tmdb(Provider):
             for entry in response["results"]:
                 try:
                     meta = MetadataMovie(
-                        id_tmdb=entry["id"],
+                        id_tmdb=str(entry["id"]),
                         name=entry["title"],
                         language=language,
-                        synopsis=entry["overview"],
-                        year=entry["release_date"],
+                        synopsis=entry.get("overview"),
+                        year=entry.get("release_date"),
                     )
                     if not meta.year:
                         continue
@@ -210,10 +245,11 @@ class Tmdb(Provider):
             raise MnamerNotFoundException
 
 
-class Tvdb(Provider):
+class Tvdb(Provider[MetadataEpisode]):
     """Queries the TVDb API."""
 
-    api_key: str = environ.get("API_KEY_TVDB", "E69C7A2CEF2F3152")
+    api_key: str | None = environ.get("API_KEY_TVDB", "E69C7A2CEF2F3152")
+    token: str
 
     def __init__(self, api_key: str | None = None, cache: bool = True):
         super().__init__(api_key, cache)
@@ -223,6 +259,7 @@ class Tvdb(Provider):
     def _login(self) -> str:
         return tvdb_login(self.api_key)
 
+    @override
     def search(self, query: MetadataEpisode) -> Iterator[MetadataEpisode]:
         """Searches TVDb for movie metadata."""
         assert query
@@ -250,7 +287,7 @@ class Tvdb(Provider):
         season: int | None = None,
         episode: int | None = None,
         language: Language | None = None,
-    ):
+    ) -> Iterator[MetadataEpisode]:
         found = False
         series_data = tvdb_series_id(
             self.token, id_tvdb, language=language, cache=self.cache
@@ -269,17 +306,17 @@ class Tvdb(Provider):
             for entry in episode_data["data"]:
                 try:
                     yield MetadataEpisode(
-                        date=entry["firstAired"],
-                        episode=entry["airedEpisodeNumber"],
+                        date=parse_date(entry["first_aired"]),
+                        episode=entry["aired_episode_number"],
                         id_tvdb=id_tvdb,
-                        season=entry["airedSeason"],
-                        series=series_data["data"]["seriesName"],
+                        season=entry["aired_season"],
+                        series=series_data["data"]["series_name"],
                         language=language,
                         synopsis=(entry["overview"] or "")
                         .replace("\r\n", "")
                         .replace("  ", "")
                         .strip(),
-                        title=entry["episodeName"].split(";", 1)[0],
+                        title=entry["episode_name"].split(";", 1)[0],
                     )
                     found = True
                 except (AttributeError, KeyError, ValueError):
@@ -296,13 +333,13 @@ class Tvdb(Provider):
         season: int | None,
         episode: int | None,
         language: Language | None,
-    ):
+    ) -> Iterator[MetadataEpisode]:
         found = False
         series_data = tvdb_search_series(
             self.token, series, language=language, cache=self.cache
         )
 
-        for series_id in [entry["id"] for entry in series_data["data"][:5]]:
+        for series_id in [str(entry["id"]) for entry in series_data["data"][:5]]:
             try:
                 for data in self._search_id(series_id, season, episode, language):
                     if not data.series or not data.season:
@@ -316,7 +353,7 @@ class Tvdb(Provider):
 
     def _search_tvdb_date(
         self, id_tvdb: str, release_date: dt.date, language: Language | None
-    ):
+    ) -> Iterator[MetadataEpisode]:
         release_date = parse_date(release_date)
         found = False
         for meta in self._search_id(id_tvdb, language=language):
@@ -328,12 +365,12 @@ class Tvdb(Provider):
 
     def _search_series_date(
         self, series: str, release_date: dt.date, language: Language | None
-    ):
+    ) -> Iterator[MetadataEpisode]:
         release_date = parse_date(release_date)
         series_data = tvdb_search_series(
             self.token, series, language=language, cache=self.cache
         )
-        tvdb_ids = [entry["id"] for entry in series_data["data"]][:5]
+        tvdb_ids = [str(entry["id"]) for entry in series_data["data"][:5]]
         found = False
         for tvdb_id in tvdb_ids:
             try:
@@ -345,11 +382,14 @@ class Tvdb(Provider):
             raise MnamerNotFoundException
 
 
-class TvMaze(Provider):
+class TvMaze(Provider[MetadataEpisode]):
     """Queries the TVMaze API."""
 
-    api_key = environ.get("API_KEY_TVMAZE", "wxadpr5W7yWma_QYaHM4BB_l80WIIjcK")
+    api_key: str | None = environ.get(
+        "API_KEY_TVMAZE", "wxadpr5W7yWma_QYaHM4BB_l80WIIjcK"
+    )
 
+    @override
     def search(self, query: MetadataEpisode) -> Iterator[MetadataEpisode]:
         if query.id_tvmaze and query.season and query.episode:
             yield from self._lookup_with_tmaze_id_and_season_and_episode(
@@ -372,12 +412,16 @@ class TvMaze(Provider):
         else:
             raise MnamerNotFoundException
 
+    @staticmethod
+    def _opt_str(value: int | str | None) -> str | None:
+        return str(value) if value else None
+
     def _lookup_with_tmaze_id_and_season_and_episode(
         self, id_tvmaze: str, season: int | None, episode: int | None
     ) -> Iterator[MetadataEpisode]:
         series_data = tvmaze_show(id_tvmaze)
         episode_data = tvmaze_episode_by_number(id_tvmaze, season, episode)
-        id_tvdb = series_data["externals"]["thetvdb"]
+        id_tvdb = self._opt_str(series_data["externals"].get("thetvdb"))
         yield self._transform_meta(id_tvmaze, id_tvdb, series_data, episode_data)
 
     def _lookup_with_id_and_date(
@@ -387,10 +431,10 @@ class TvMaze(Provider):
         if id_tvmaze:
             series_data = tvmaze_show(id_tvmaze)
             query_id_tvmaze = id_tvmaze
-            query_id_tvdb = series_data["externals"]["thetvdb"]
+            query_id_tvdb = self._opt_str(series_data["externals"].get("thetvdb"))
         else:
             series_data = tvmaze_show_lookup(id_tvdb=id_tvdb)
-            query_id_tvmaze = series_data["id"]
+            query_id_tvmaze = str(series_data["id"])
             query_id_tvdb = id_tvdb
         episode_data = tvmaze_episodes_by_date(query_id_tvmaze, air_date)
         for episode_entry in episode_data:
@@ -409,11 +453,11 @@ class TvMaze(Provider):
         if id_tvmaze:
             query_id_tvmaze = id_tvmaze
             series_data = tvmaze_show(id_tvmaze)
-            query_id_tvdb = series_data["externals"]["thetvdb"]
+            query_id_tvdb = self._opt_str(series_data["externals"].get("thetvdb"))
         else:
             series_data = tvmaze_show_lookup(id_tvdb=id_tvdb)
             query_id_tvdb = id_tvdb
-            query_id_tvmaze = series_data["id"]
+            query_id_tvmaze = str(series_data["id"])
         episode_data = tvmaze_show_episodes_list(query_id_tvmaze)
         for episode_entry in episode_data:
             meta = self._transform_meta(
@@ -430,17 +474,17 @@ class TvMaze(Provider):
     ) -> Iterator[MetadataEpisode]:
         assert season
         series_data = tvmaze_show_search(series)
-        for idx, series_entry in enumerate(series_data):
+        for idx, search_entry in enumerate(series_data):
             if idx >= 3:
                 break
-            series_entry = series_entry["show"]
-            id_tvmaze = series_entry["id"]
+            series_entry = search_entry["show"]
+            id_tvmaze = str(series_entry["id"])
             try:
                 episode_entry = tvmaze_episode_by_number(id_tvmaze, season, episode)
             except MnamerNotFoundException:
                 continue
             meta = self._transform_meta(id_tvmaze, None, series_entry, episode_entry)
-            if season is not None and season != meta.season:
+            if season != meta.season:
                 continue
             if episode is not None and episode != meta.episode:
                 continue
@@ -451,14 +495,14 @@ class TvMaze(Provider):
     ) -> Iterator[MetadataEpisode]:
         assert series
         series_data = tvmaze_show_search(series)
-        for idx, series_entry in enumerate(series_data):
+        for idx, search_entry in enumerate(series_data):
             if idx >= 3:
                 break
-            series_entry = series_entry["show"]
-            id_tvmaze = series_entry["id"]
+            series_entry = search_entry["show"]
+            id_tvmaze = str(series_entry["id"])
             episode_data = tvmaze_show_episodes_list(id_tvmaze)
             for episode_entry in episode_data:
-                id_tvdb = series_entry["externals"]["thetvdb"]
+                id_tvdb = self._opt_str(series_entry["externals"].get("thetvdb"))
                 meta = self._transform_meta(
                     id_tvmaze, id_tvdb, series_entry, episode_entry
                 )
@@ -470,10 +514,14 @@ class TvMaze(Provider):
 
     @staticmethod
     def _transform_meta(
-        id_tvmaze: str, id_tvdb: str | None, series_entry: dict, episode_entry: dict
+        id_tvmaze: str,
+        id_tvdb: str | None,
+        series_entry: TvMazeShow,
+        episode_entry: TvMazeEpisode,
     ) -> MetadataEpisode:
+        airdate = episode_entry["airdate"]
         return MetadataEpisode(
-            date=episode_entry["airdate"] or None,
+            date=parse_date(airdate) if airdate else None,
             episode=episode_entry["number"],
             id_tvdb=id_tvdb or None,
             id_tvmaze=id_tvmaze or None,

--- a/mnamer/setting_spec.py
+++ b/mnamer/setting_spec.py
@@ -24,8 +24,6 @@ class SettingSpec:
         """Converts ArgSpec instance into a Python dictionary."""
         return {k: v for k, v in vars(self).items() if k}
 
-    __call__ = as_dict
-
     @property
     def registration(self) -> tuple[list[str], dict[str, Any]]:
         names = self.flags or []

--- a/mnamer/setting_store.py
+++ b/mnamer/setting_store.py
@@ -2,7 +2,7 @@ import dataclasses
 import json
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, override
 
 from mnamer.argument import ArgLoader
 from mnamer.const import SUBTITLE_CONTAINERS
@@ -368,8 +368,9 @@ class SettingStore:
     def _resolve_path(path: str | Path) -> Path:
         return Path(path).resolve()
 
+    @override
     def __setattr__(self, key: str, value: Any):
-        converter_map: dict[str, Callable] = {
+        converter_map: dict[str, Callable[[Any], Any]] = {
             "episode_api": ProviderType,
             "episode_directory": self._resolve_path,
             "language": Language.parse,
@@ -379,7 +380,7 @@ class SettingStore:
             "movie_directory": self._resolve_path,
             "targets": lambda targets: [Path(target) for target in targets],
         }
-        converter: Callable | None = converter_map.get(key)
+        converter: Callable[[Any], Any] | None = converter_map.get(key)
         if value is not None and converter:
             value = converter(value)
         super().__setattr__(key, value)
@@ -442,9 +443,7 @@ class SettingStore:
 
     def api_key_for(self, provider_type: ProviderType) -> str | None:
         """Returns the API key for a provider type."""
-        if provider_type:
-            return getattr(self, f"api_key_{provider_type.value}")
-        return None
+        return getattr(self, f"api_key_{provider_type.value}")
 
     def formatting_for(self, media: MediaType | Metadata) -> str:
         """Returns the formatting string for a given media type or metadata."""

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -4,7 +4,7 @@ import datetime as dt
 from os import path
 from pathlib import Path
 from shutil import move
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Self, override
 
 from guessit import guessit  # type: ignore
 
@@ -29,14 +29,12 @@ from mnamer.utils import (
 class Target:
     """Manages metadata state for a media file and facilitates its relocation."""
 
-    _providers: ClassVar[dict[ProviderType, Provider]] = {}
+    _providers: ClassVar[dict[ProviderType, Provider[Any]]] = {}
 
     _settings: SettingStore
-    _provider: Provider
+    _provider: Provider[Any]
     _has_moved: bool
     _has_renamed: bool
-    _raw_metadata: dict[str, str]
-    _parsed_metadata: Metadata
 
     source: Path
     metadata: Metadata
@@ -51,14 +49,12 @@ class Target:
         self._override_metadata_ids()
         self._register_provider()
 
+    @override
     def __str__(self) -> str:
-        if isinstance(self.source, Path):
-            return str(self.source.resolve())
-        else:
-            return str(self.source)
+        return str(self.source.resolve())
 
     @classmethod
-    def populate_paths(cls: type[Target], settings: SettingStore) -> list[Target]:
+    def populate_paths(cls, settings: SettingStore) -> list[Self]:
         """Creates a list of Target objects for media files found in paths."""
         file_paths = crawl_in(settings.targets, settings.recurse)
         file_paths = filter_blacklist(file_paths, settings.ignore)
@@ -245,6 +241,6 @@ class Target:
         destination_path = Path(self.destination).resolve()
         destination_path.parent.mkdir(parents=True, exist_ok=True)
         try:
-            move(str(self.source), destination_path)
+            _dest = move(str(self.source), destination_path)
         except OSError as e:  # pragma: no cover
             raise MnamerException from e

--- a/mnamer/tty.py
+++ b/mnamer/tty.py
@@ -46,20 +46,16 @@ def _abort_helpers() -> tuple[
     )
 
 
-def _msg_format(body: Any):
-    converter_map: dict[type, Callable] = {
+def _msg_format(body: Any) -> str:
+    converter_map: dict[type, Callable[[Any], str]] = {
         dict: format_dict,
         list: format_iter,
         tuple: format_iter,
         set: format_iter,
         MnamerException: format_exception,
     }
-    converter: Callable | None = converter_map.get(type(body), str)
-    if converter:
-        body = converter(body)
-    else:
-        body = getattr(body, "value", body)
-    return body
+    converter: Callable[[Any], str] = converter_map.get(type(body), str)
+    return converter(body)
 
 
 def configure(settings: SettingStore):

--- a/mnamer/types.py
+++ b/mnamer/types.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Self
 
 
 class MediaType(Enum):
@@ -10,7 +11,7 @@ class MediaType(Enum):
     MOVIE = "movie"
 
     @classmethod
-    def to_media_type(cls) -> type[MediaType]:
+    def to_media_type(cls) -> type[Self]:
         return cls
 
 

--- a/mnamer/utils.py
+++ b/mnamer/utils.py
@@ -3,7 +3,7 @@
 import datetime as dt
 import json
 import re
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from os import walk
 from os.path import exists, expanduser, expandvars, getsize, splitdrive, splitext
 from pathlib import Path, PurePath
@@ -16,7 +16,9 @@ from requests.adapters import HTTPAdapter
 from mnamer.const import CACHE_PATH, CURRENT_YEAR, SUBTITLE_CONTAINERS
 
 
-def clean_dict(target_dict: dict, whitelist=None) -> dict:
+def clean_dict(
+    target_dict: dict[str, Any], whitelist: Iterable[str] | None = None
+) -> dict[str, str]:
     """Convenience function that removes a dicts keys that have falsy values."""
     return {
         str(k).strip(): str(v).strip()
@@ -94,7 +96,7 @@ def filter_containers(
     ]
 
 
-def findall(s, ss) -> Iterator[int]:
+def findall(s: str, ss: str) -> Iterator[int]:
     """Yields indexes of all start positions of substring matches in string."""
     i = s.find(ss)
     while i != -1:
@@ -102,15 +104,15 @@ def findall(s, ss) -> Iterator[int]:
         i = s.find(ss, i + 1)
 
 
-def fn_chain(*fn_list: Callable) -> Callable:
+def fn_chain(*fn_list: Callable[..., Any]) -> Callable[..., tuple[Any, ...]]:
     """Chains a list of function calls into one."""
     return lambda *args, **kwargs: tuple(fn(*args, **kwargs) for fn in fn_list)
 
 
-def fn_pipe(*fn_list: Callable) -> Callable:
-    """Pipes a list of function calls into one."""
+def fn_pipe[T](*fn_list: Callable[[T], T]) -> Callable[[T], T]:
+    """Pipes a list of function calls (each `T -> T`) into one."""
 
-    def resolver(x):
+    def resolver(x: T) -> T:
         for fn in fn_list:
             x = fn(x)
         return x
@@ -118,7 +120,7 @@ def fn_pipe(*fn_list: Callable) -> Callable:
     return resolver
 
 
-def format_dict(body: dict) -> str:
+def format_dict(body: dict[str, Any]) -> str:
     """
     Formats a dictionary into a multi-line bulleted string of key-value pairs.
     """
@@ -129,7 +131,7 @@ def format_exception(body: Exception) -> str:
     return str(body)
 
 
-def format_iter(body: list) -> str:
+def format_iter(body: list[Any]) -> str:
     """
     Formats an iterable into a multi-line bulleted string of its values.
     """
@@ -143,26 +145,22 @@ def is_subtitle(container: str | Path | None) -> bool:
     return str(container).endswith(tuple(SUBTITLE_CONTAINERS))
 
 
-def get_session() -> requests_cache.CachedSession:
-    """Convenience function that returns request-cache session singleton."""
+_session: requests_cache.CachedSession | None = None
 
-    def make_session():
-        session = requests_cache.CachedSession(
+
+def get_session() -> requests_cache.CachedSession:
+    """Returns a cached requests-cache session singleton."""
+    global _session
+    if _session is None:
+        _session = requests_cache.CachedSession(
             cache_name=str(CACHE_PATH),
             extension=".sqlite",
             expire_after=518_400,  # 6 days
         )
         adapter = HTTPAdapter(max_retries=3)
-        session.mount("http://", adapter)
-        session.mount("https://", adapter)
-        return session
-
-    if hasattr(get_session, "session"):
-        session: requests_cache.CachedSession = get_session.session  # type: ignore[attr-defined]
-        return session
-    session = make_session()
-    get_session.session = session  # type: ignore[attr-defined]
-    return session
+        _session.mount("http://", adapter)
+        _session.mount("https://", adapter)
+    return _session
 
 
 def get_filesize(path: Path) -> str:
@@ -212,6 +210,28 @@ def normalize_containers(container_list: list[str]) -> list[str]:
     return [normalize_container(container) for container in container_list]
 
 
+_CAMEL_TO_SNAKE_PATTERN_1 = re.compile(r"(.)([A-Z][a-z]+)")
+_CAMEL_TO_SNAKE_PATTERN_2 = re.compile(r"([a-z0-9])([A-Z])")
+
+
+def to_snake_case(s: str) -> str:
+    """Converts a camelCase or PascalCase string to snake_case (e.g. imdbID -> imdb_id)."""
+    s = _CAMEL_TO_SNAKE_PATTERN_1.sub(r"\1_\2", s)
+    s = _CAMEL_TO_SNAKE_PATTERN_2.sub(r"\1_\2", s)
+    return s.lower()
+
+
+def normalize_keys(value: Any) -> Any:
+    """Recursively rewrites dict keys in a JSON-like value to snake_case."""
+    if isinstance(value, dict):
+        items: dict[Any, Any] = value
+        return {to_snake_case(str(k)): normalize_keys(v) for k, v in items.items()}
+    if isinstance(value, list):
+        items_list: list[Any] = value
+        return [normalize_keys(item) for item in items_list]
+    return value
+
+
 def parse_date(value: str | dt.date | dt.datetime) -> dt.date:
     """Converts an ambiguously formatted date type into a date object."""
     if isinstance(value, str):
@@ -224,14 +244,14 @@ def parse_date(value: str | dt.date | dt.datetime) -> dt.date:
 
 
 def request_json(
-    url,
-    parameters: dict | list | None = None,
-    body: dict | None = None,
-    headers: dict | None = None,
+    url: str,
+    parameters: dict[str, Any] | list[tuple[str, Any]] | None = None,
+    body: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
     cache: bool = True,
-) -> tuple[int, dict]:
+) -> tuple[int, Any]:
     """
-    Queries a url for json data.
+    Queries a url for json data; the response shape is API-specific (dict or list).
 
     Note: Requests are cached using requests_cached for a week, this is done
     transparently by using the package's monkey patching.
@@ -239,10 +259,7 @@ def request_json(
     assert url
     session = get_session()
 
-    if isinstance(headers, dict):
-        headers = clean_dict(headers)
-    else:
-        headers = {}
+    headers = clean_dict(headers) if headers else {}
     if isinstance(parameters, dict):
         parameters = [(k, v) for k, v in clean_dict(parameters).items()]
     if body:
@@ -256,9 +273,10 @@ def request_json(
         "like Gecko) Chrome/79.0.3945.88 Safari/537.36"
     )
 
-    initial_cache_state = session._disabled  # yes, i'm a bad person
+    # requests-cache has no public API for per-request cache disable; access internal flag.
+    initial_cache_state = session._disabled  # pyright: ignore[reportPrivateUsage]
     try:
-        session._disabled = not cache
+        session._disabled = not cache  # pyright: ignore[reportPrivateUsage]
         response = session.request(
             url=url,
             params=parameters,
@@ -273,8 +291,8 @@ def request_json(
         content = None
         status = 500
     finally:
-        session._disabled = initial_cache_state
-    return status, (content or {})
+        session._disabled = initial_cache_state  # pyright: ignore[reportPrivateUsage]
+    return status, (content if content is not None else {})
 
 
 def str_fix_padding(s: str) -> str:
@@ -325,7 +343,6 @@ def str_sanitize(filename: str) -> str:
 def str_scenify(filename: str) -> str:
     """Replaces non ascii-alphanumerics with dots."""
     filename = normalize("NFKD", filename)
-    filename.encode("ascii", "ignore")
     filename = re.sub(r"\s+", ".", filename)
     filename = re.sub(r"[^.\d\w/]", "", filename)
     filename = re.sub(r"\.+", ".", filename)
@@ -466,8 +483,8 @@ def str_title_case(s: str) -> str:
     for exception in uppercase_exceptions:
         for pos in findall(string_lower, exception):
             is_start = pos == 0
-            prev_char = None if is_start else string_lower[pos - 1]  # type: ignore
-            is_left_partitioned = is_start or prev_char in partition_chars  # type: ignore
+            prev_char = "" if is_start else string_lower[pos - 1]
+            is_left_partitioned = is_start or prev_char in partition_chars
             word_length = len(exception)
             ends = pos + word_length == string_length
             next_char = "" if ends else string_lower[pos + word_length]
@@ -492,9 +509,10 @@ def year_range_parse(years: str | int | None, tolerance: int = 1) -> tuple[int, 
     regex = r"^((?:19|20)\d{2})?([-,: ]*)?((?:19|20)\d{2})?$"
     default_start = 1900
     default_end = CURRENT_YEAR
-    try:
-        start, dash, end = re.match(regex, str(years).strip()).groups()  # type: ignore
-    except AttributeError:
+    match = re.match(regex, str(years).strip())
+    if match:
+        start, dash, end = match.groups()
+    else:
         start, end, dash = None, None, True
     if not start and not end:
         start, end, dash = None, None, True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,11 +73,14 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 
 [tool.pyright]
-reportGeneralTypeIssues = "information"
 pythonVersion = "3.12"
 include = ["mnamer"]
-exclude = ["playground.py", "venv"]
+exclude = ["playground.py", ".venv", "venv", "build", "dist", "tests"]
 venv = "venv"
+reportAny = false
+reportExplicitAny = false
+reportGeneralTypeIssues = "information"
+reportMissingTypeStubs = false
 
 [tool.ruff.lint.isort]
 known-first-party = ["mnamer"]

--- a/tests/local/test_utils.py
+++ b/tests/local/test_utils.py
@@ -499,7 +499,7 @@ def test_normalize_container__has_dot():
 def test_request_json__status(mock_request, code):
     mock_response = MockRequestResponse(code, "{}")
     mock_request.return_value = mock_response
-    status, _ = request_json("http://...", cache=False)
+    status, _content = request_json("http://...", cache=False)
     assert status == code
 
 

--- a/tests/network/test_endpoints__omdb.py
+++ b/tests/network/test_endpoints__omdb.py
@@ -46,70 +46,70 @@ def test_omdb_title__title_id_xnor__neither(mock_request):
 
 def test_omdb_title__media__movie():
     expected_top_level_keys = {
-        "Actors",
-        "Awards",
-        "BoxOffice",
-        "Country",
-        "Director",
-        "DVD",
-        "Genre",
-        "imdbID",
-        "imdbRating",
-        "imdbVotes",
-        "Language",
-        "Metascore",
-        "Plot",
-        "Poster",
-        "Production",
-        "Rated",
-        "Ratings",
-        "Released",
-        "Response",
-        "Runtime",
-        "Title",
-        "Type",
-        "Website",
-        "Writer",
-        "Year",
+        "actors",
+        "awards",
+        "box_office",
+        "country",
+        "director",
+        "dvd",
+        "genre",
+        "imdb_id",
+        "imdb_rating",
+        "imdb_votes",
+        "language",
+        "metascore",
+        "plot",
+        "poster",
+        "production",
+        "rated",
+        "ratings",
+        "released",
+        "response",
+        "runtime",
+        "title",
+        "type",
+        "website",
+        "writer",
+        "year",
     }
     result = omdb_title(Omdb.api_key, media="movie", title="ninja turtles")
     assert_has_keys(result, expected_top_level_keys)
-    assert result["Response"]
-    assert result["Type"] == "movie"
-    assert result["Title"] == "Teenage Mutant Ninja Turtles"
+    assert result["response"]
+    assert result["type"] == "movie"
+    assert result["title"] == "Teenage Mutant Ninja Turtles"
 
 
 def test_omdb_title__media__series():
     expected_top_level_keys = {
-        "Actors",
-        "Awards",
-        "Country",
-        "Director",
-        "Genre",
-        "imdbID",
-        "imdbRating",
-        "imdbVotes",
-        "Language",
-        "Metascore",
-        "Plot",
-        "Poster",
-        "Rated",
-        "Ratings",
-        "Released",
-        "Response",
-        "Runtime",
-        "Title",
-        "totalSeasons",
-        "Type",
-        "Writer",
-        "Year",
+        "actors",
+        "awards",
+        "country",
+        "director",
+        "genre",
+        "imdb_id",
+        "imdb_rating",
+        "imdb_votes",
+        "language",
+        "metascore",
+        "plot",
+        "poster",
+        "rated",
+        "ratings",
+        "released",
+        "response",
+        "runtime",
+        "title",
+        "total_seasons",
+        "type",
+        "writer",
+        "year",
     }
 
     result = omdb_title(Omdb.api_key, media="series", title="ninja turtles")
     assert_has_keys(result, expected_top_level_keys)
-    assert result["Response"]
-    assert result["Type"] == "series"
-    assert result["Title"] == "Teenage Mutant Ninja Turtles"
+    assert result["response"]
+    assert result["type"] == "series"
+    assert result["title"] == "Teenage Mutant Ninja Turtles"
 
 
 def test_omdb_title__api_key_fail():
@@ -133,25 +133,25 @@ def test_omdb_title__invalid_plot():
 
 
 def test_omdb_search__fields__top_level():
-    expected_fields = {"Search", "Response", "totalResults"}
+    expected_fields = {"search", "response", "total_results"}
     result = omdb_search(Omdb.api_key, "ninja turtles")
     assert_has_keys(result, expected_fields)
 
 
 def test_omdb_search__fields__search():
-    expected_fields = {"Title", "Year", "imdbID", "Type", "Poster"}
-    result = omdb_search(Omdb.api_key, "ninja turtles")["Search"][0]
+    expected_fields = {"title", "year", "imdb_id", "type", "poster"}
+    result = omdb_search(Omdb.api_key, "ninja turtles")["search"][0]
     assert_has_keys(result, expected_fields)
 
 
 def test_omdb_search__query__movie():
     result = omdb_search(Omdb.api_key, "ninja turtles", media="movie")
-    assert all(entry["Type"] == "movie" for entry in result["Search"])
+    assert all(entry["type"] == "movie" for entry in result["search"])
 
 
 def test_omdb_search__query__series():
     result = omdb_search(Omdb.api_key, "ninja turtles", media="series")
-    assert all(entry["Type"] == "series" for entry in result["Search"])
+    assert all(entry["type"] == "series" for entry in result["search"])
 
 
 def test_omdb_search__api_key_fail():
@@ -166,7 +166,7 @@ def test_omdb_search__query__fail():
 
 def test_omdb_search__year():
     result = omdb_search(Omdb.api_key, "ninja turtles", year=1987)
-    assert "tt0131613" == result["Search"][0]["imdbID"]
+    assert "tt0131613" == result["search"][0]["imdb_id"]
 
 
 def test_omdb_search__page_diff():

--- a/tests/network/test_endpoints__tvdb.py
+++ b/tests/network/test_endpoints__tvdb.py
@@ -21,39 +21,39 @@ pytestmark = [
 ]
 
 EXPECTED_TOP_LEVEL_SHOW_KEYS = {
-    "absoluteNumber",
-    "airedEpisodeNumber",
-    "airedSeason",
-    "airedSeasonID",
-    "airsAfterSeason",
-    "airsBeforeEpisode",
-    "airsBeforeSeason",
-    "contentRating",
+    "absolute_number",
+    "aired_episode_number",
+    "aired_season",
+    "aired_season_id",
+    "airs_after_season",
+    "airs_before_episode",
+    "airs_before_season",
+    "content_rating",
     "directors",
-    "dvdChapter",
-    "dvdDiscid",
-    "dvdEpisodeNumber",
-    "dvdSeason",
-    "episodeName",
+    "dvd_chapter",
+    "dvd_discid",
+    "dvd_episode_number",
+    "dvd_season",
+    "episode_name",
     "filename",
-    "firstAired",
-    "guestStars",
+    "first_aired",
+    "guest_stars",
     "id",
-    "imdbId",
-    "isMovie",
+    "imdb_id",
+    "is_movie",
     "language",
-    "lastUpdated",
-    "lastUpdatedBy",
+    "last_updated",
+    "last_updated_by",
     "overview",
-    "productionCode",
-    "seriesId",
-    "showUrl",
-    "siteRating",
-    "siteRatingCount",
-    "thumbAdded",
-    "thumbAuthor",
-    "thumbHeight",
-    "thumbWidth",
+    "production_code",
+    "series_id",
+    "show_url",
+    "site_rating",
+    "site_rating_count",
+    "thumb_added",
+    "thumb_author",
+    "thumb_height",
+    "thumb_width",
     "writers",
 }
 
@@ -123,13 +123,13 @@ def test_tvdb_episodes_id__success(tvdb_token):
     assert isinstance(result, dict)
     assert "data" in result
     assert_has_keys(result["data"], EXPECTED_TOP_LEVEL_SHOW_KEYS)
-    assert str(result["data"]["seriesId"]) == LOST_TVDB_ID_SERIES
+    assert str(result["data"]["series_id"]) == LOST_TVDB_ID_SERIES
     assert str(result["data"]["id"]) == LOST_TVDB_ID_EPISODE
 
 
 def test_tvdb_episodes_id__language(tvdb_token):
     result = tvdb_episodes_id(tvdb_token, LOST_TVDB_ID_EPISODE, RUSSIAN_LANG)
-    assert result["data"]["episodeName"] == "Пилот (1)"
+    assert result["data"]["episode_name"] == "Пилот (1)"
 
 
 def test_tvdb_episodes_id__language__invalid(tvdb_token):
@@ -167,32 +167,32 @@ def test_tvdb_series_id__no_hits(tvdb_token):
 def test_tvdb_series_id__success(tvdb_token):
     expected_top_level_keys = {
         "added",
-        "addedBy",
-        "airsDayOfWeek",
-        "airsTime",
+        "added_by",
+        "airs_day_of_week",
+        "airs_time",
         "aliases",
         "banner",
         "fanart",
-        "firstAired",
+        "first_aired",
         "genre",
         "id",
-        "imdbId",
+        "imdb_id",
         "language",
-        "lastUpdated",
+        "last_updated",
         "network",
-        "networkId",
+        "network_id",
         "overview",
         "poster",
         "rating",
         "runtime",
         "season",
-        "seriesId",
-        "seriesName",
-        "siteRating",
-        "siteRatingCount",
+        "series_id",
+        "series_name",
+        "site_rating",
+        "site_rating_count",
         "slug",
         "status",
-        "zap2itId",
+        "zap2it_id",
     }
 
     result = tvdb_series_id(tvdb_token, LOST_TVDB_ID_SERIES)
@@ -200,12 +200,12 @@ def test_tvdb_series_id__success(tvdb_token):
     assert "data" in result
     assert_has_keys(result["data"], expected_top_level_keys)
     assert str(result["data"]["id"]) == LOST_TVDB_ID_SERIES
-    assert result["data"]["seriesName"] == "Lost"
+    assert result["data"]["series_name"] == "Lost"
 
 
 def test_tvdb_series_id__language(tvdb_token):
     result = tvdb_series_id(tvdb_token, THE_WITCHER_ID_SERIES, RUSSIAN_LANG)
-    assert result["data"]["seriesName"] == "Ведьмак"
+    assert result["data"]["series_name"] == "Ведьмак"
 
 
 @pytest.mark.xfail(strict=False)
@@ -247,7 +247,7 @@ def test_tvdb_series_id_episodes__language(tvdb_token):
     result = tvdb_series_id_episodes(
         tvdb_token, THE_WITCHER_ID_SERIES, language=RUSSIAN_LANG
     )
-    assert result["data"][0]["episodeName"] == "Начало конца"
+    assert result["data"][0]["episode_name"] == "Начало конца"
 
 
 @pytest.mark.xfail(strict=False)
@@ -340,7 +340,7 @@ def test_tvdb_series_id_episodes_query(tvdb_token):
         episode=1,
         language=RUSSIAN_LANG,
     )
-    assert result["data"][0]["episodeName"] == "Начало конца"
+    assert result["data"][0]["episode_name"] == "Начало конца"
 
 
 def test_tvdb_search_series__invalid_token():
@@ -367,13 +367,13 @@ def test_tvdb_search_series__success(tvdb_token):
     expected_top_level_keys = {
         "aliases",
         "banner",
-        "firstAired",
+        "first_aired",
         "id",
         "image",
         "network",
         "overview",
         "poster",
-        "seriesName",
+        "series_name",
         "slug",
         "status",
     }
@@ -387,4 +387,4 @@ def test_tvdb_search_series__success(tvdb_token):
 
 def test_tvdb_search_series__language(tvdb_token):
     results = tvdb_search_series(tvdb_token, "Witcher", language=RUSSIAN_LANG)
-    assert any(result["seriesName"] for result in results["data"])
+    assert any(result["series_name"] for result in results["data"])

--- a/tests/network/test_endpoints__tvmaze.py
+++ b/tests/network/test_endpoints__tvmaze.py
@@ -21,7 +21,7 @@ pytestmark = [
 META = EPISODE_META["The Walking Dead"]
 EXPECTED_SHOW_KEYS = [
     "_links",
-    "dvdCountry",
+    "dvd_country",
     "externals",
     "genres",
     "id",
@@ -29,7 +29,7 @@ EXPECTED_SHOW_KEYS = [
     "language",
     "name",
     "network",
-    "officialSite",
+    "official_site",
     "premiered",
     "rating",
     "runtime",
@@ -39,7 +39,7 @@ EXPECTED_SHOW_KEYS = [
     "type",
     "updated",
     "url",
-    "webChannel",
+    "web_channel",
     "weight",
 ]
 
@@ -80,7 +80,7 @@ def test_tvmaze_show__embed_episodes():
         "language",
         "name",
         "network",
-        "officialSite",
+        "official_site",
         "premiered",
         "rating",
         "runtime",
@@ -90,7 +90,7 @@ def test_tvmaze_show__embed_episodes():
         "type",
         "updated",
         "url",
-        "webChannel",
+        "web_channel",
         "weight",
     ]
     result = tvmaze_show(id_tvmaze=META["id_tvmaze"], embed_episodes=True)

--- a/tests/network/test_providers__tmdb.py
+++ b/tests/network/test_providers__tmdb.py
@@ -35,7 +35,9 @@ def test_search_id__no_hits(provider: Tmdb):
 @pytest.mark.parametrize("meta", MOVIE_META.values(), ids=list(MOVIE_META))
 def test_search__name(meta: dict, provider: Tmdb):
     query = MetadataMovie(name=meta["name"])
-    assert any(result.id_tmdb == meta["id_tmdb"] for result in provider.search(query))
+    assert any(
+        result.id_tmdb == str(meta["id_tmdb"]) for result in provider.search(query)
+    )
 
 
 def test_search__no_hits(provider: Tmdb):

--- a/tests/network/test_providers__tvdb.py
+++ b/tests/network/test_providers__tvdb.py
@@ -37,7 +37,9 @@ def test_search_id__no_hits(provider: Tvdb):
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
 def test_search__series(meta: dict, provider: Tvdb):
     query = MetadataEpisode(series=meta["series"])
-    assert any(result.id_tvdb == meta["id_tvdb"] for result in provider.search(query))
+    assert any(
+        result.id_tvdb == str(meta["id_tvdb"]) for result in provider.search(query)
+    )
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
@@ -71,7 +73,7 @@ def test_tvdb_provider__search__series(meta: dict, provider: Tvdb):
     found = False
     results = provider.search(query)
     for result in results:
-        if result.id_tvdb == meta["id_tvdb"]:
+        if result.id_tvdb == str(meta["id_tvdb"]):
             found = True
             break
     assert found is True
@@ -80,7 +82,7 @@ def test_tvdb_provider__search__series(meta: dict, provider: Tvdb):
 def test_tvdb_provider__search__series_deep(provider: Tvdb):
     query = MetadataEpisode(series="House Rules (au)", season=6, episode=6)
     results = provider.search(query)
-    assert any(result.id_tvdb == 269795 for result in results)
+    assert any(result.id_tvdb == "269795" for result in results)
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))


### PR DESCRIPTION
## Summary
- Refactors `const.py` version/cache-dir resolution into helper functions
- Normalize all metadata-provider API responses to snake_case via new `normalize_keys` helper; introduce `TypedDict` shapes for endpoint returns
- Adopts Python 3.12+ typing (`@override`, `Self`, `TypedDict`, generics) across the package
- Tightens pyright configuration