### PR TITLE
Fix uv dependency publishing

### DIFF
--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.12'
-        
+
     - name: Install uv
       uses: astral-sh/setup-uv@v4
       with:
@@ -16,4 +16,4 @@ runs:
 
     - name: Install dependencies
       shell: sh
-      run: uv sync --dev
+      run: uv sync --locked --dev

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/uv.lock
+++ b/uv.lock
@@ -574,7 +574,7 @@ requires-dist = [
     { name = "appdirs", specifier = "~=1.4.4" },
     { name = "babelfish", specifier = "~=0.6.1" },
     { name = "guessit", specifier = "~=3.8.0" },
-    { name = "requests", specifier = "~=2.33.1" },
+    { name = "requests", specifier = ">=2.33.1,<2.35.0" },
     { name = "requests-cache", specifier = "~=1.3.1" },
     { name = "setuptools-scm", specifier = ">=10.0.0" },
     { name = "teletype", specifier = "~=1.3.4" },


### PR DESCRIPTION
Use uv Dependabot updates, enforce locked installs, and restrict PyPI publish to release events.