### PR TITLE
Apply filename transforms to generated directories

### DIFF
--- a/mnamer/providers.py
+++ b/mnamer/providers.py
@@ -103,7 +103,7 @@ class Provider[M: Metadata](ABC):
 class Omdb(Provider[MetadataMovie]):
     """Queries the OMDb API."""
 
-    api_key: str = environ.get("API_KEY_OMDB") or "477a7ebc"
+    api_key: str = environ.get("API_KEY_OMDB", "477a7ebc")
 
     def __init__(self, api_key: str = "", cache: bool = True):
         super().__init__(api_key, cache)

--- a/mnamer/providers.py
+++ b/mnamer/providers.py
@@ -103,7 +103,7 @@ class Provider[M: Metadata](ABC):
 class Omdb(Provider[MetadataMovie]):
     """Queries the OMDb API."""
 
-    api_key: str = environ.get("API_KEY_OMDB", "477a7ebc")
+    api_key: str = environ.get("API_KEY_OMDB") or "477a7ebc"
 
     def __init__(self, api_key: str = "", cache: bool = True):
         super().__init__(api_key, cache)

--- a/mnamer/setting_store.py
+++ b/mnamer/setting_store.py
@@ -366,20 +366,16 @@ class SettingStore:
             if f.metadata
         ]
 
-    @staticmethod
-    def _resolve_path(path: str | Path) -> Path:
-        return Path(path).resolve()
-
     @override
     def __setattr__(self, key: str, value: Any):
         converter_map: dict[str, Callable[[Any], Any]] = {
             "episode_api": ProviderType,
-            "episode_directory": self._resolve_path,
+            "episode_directory": Path,
             "language": Language.parse,
             "mask": normalize_containers,
             "media": MediaType,
             "movie_api": ProviderType,
-            "movie_directory": self._resolve_path,
+            "movie_directory": Path,
             "targets": lambda targets: [Path(target) for target in targets],
         }
         converter: Callable[[Any], Any] | None = converter_map.get(key)

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -141,6 +141,8 @@ class Target:
 
     def _process_path_text(self, value: str) -> str:
         """Apply replacement, scene, lower, and sanitize transforms in one place."""
+        if value in (".", ".."):
+            return value
         value = filename_replace(value, self._settings.replace_after)
         if self._settings.scene:
             value = str_scenify(value)

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -101,7 +101,7 @@ class Target:
         dir_tail, filename = self._split_formatted_path(file_path)
         directory = Path(dir_head, self._process_directory(dir_tail))
         filename = self._process_filename(filename)
-        return Path(directory, filename)
+        return Path(directory, filename).resolve()
 
     def _format_directory(self, directory: Path) -> Path:
         """Format and post-process a configured directory template.

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -104,52 +104,25 @@ class Target:
         return Path(directory, filename)
 
     def _format_directory(self, directory: Path) -> Path:
-        """Format and post-process a configured directory template."""
-        formatted = Path(format(self.metadata, str(directory)))
-        process_start = self._directory_process_start(directory)
-        if process_start is None:
-            return formatted
+        """Format and post-process a configured directory template.
 
+        Each part of the original (un-resolved) directory is formatted
+        independently so we can tell template substitutions apart from literal
+        user-typed parts. For relative paths every part is transformed; for
+        absolute paths only template parts are, keeping literal filesystem
+        prefixes like ``/Volumes/Media`` intact.
+        """
+        is_absolute = directory.is_absolute()
         processed_parts: list[str] = []
-        for idx, formatted_part in enumerate(formatted.parts):
-            if idx >= process_start:
+        for original_part in directory.parts:
+            formatted_part = format(self.metadata, original_part)
+            if not is_absolute or "{" in original_part:
                 formatted_part = self._process_path_text(formatted_part)
             processed_parts.append(formatted_part)
-        return Path(*processed_parts)
-
-    def _directory_process_start(self, directory: Path) -> int | None:
-        """
-        Return the first configured directory component that can be transformed.
-
-        ``SettingStore`` resolves relative configured directories against the
-        current working directory. In that case, only the original relative
-        portion should receive filename-style transforms. For absolute paths
-        outside cwd, keep literal parent directories intact unless the path
-        contains a template field; this prevents ``--lower`` or ``--scene`` from
-        rewriting stable filesystem prefixes such as ``/Users`` or a mountpoint.
-        """
-        cwd_parts = Path.cwd().parts
-        if directory.parts[: len(cwd_parts)] == cwd_parts:
-            return len(cwd_parts)
-
-        template_index = self._first_template_part(directory)
-        if template_index is not None:
-            return template_index
-
-        if not directory.is_absolute():
-            return 0
-
-        return None
+        return Path(*processed_parts) if processed_parts else Path()
 
     @staticmethod
-    def _first_template_part(directory: Path) -> int | None:
-        """Return the first component containing a format field, if one exists."""
-        for idx, part in enumerate(directory.parts):
-            if "{" in part:
-                return idx
-        return None
-
-    def _split_formatted_path(self, file_path: str) -> tuple[Path, str]:
+    def _split_formatted_path(file_path: str) -> tuple[Path, str]:
         """Split a formatted file template into optional directories and filename."""
         formatted_path = Path(file_path)
         dir_tail = formatted_path.parent
@@ -159,9 +132,8 @@ class Target:
 
     def _process_directory(self, directory: Path) -> Path:
         """Apply filename post-processing rules to each generated directory path."""
-        if not str(directory):
-            return Path()
-        return Path(*(self._process_path_text(part) for part in directory.parts))
+        parts = tuple(self._process_path_text(part) for part in directory.parts)
+        return Path(*parts) if parts else Path()
 
     def _process_filename(self, filename: str) -> str:
         """Apply configured post-processing rules to a generated filename."""

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime as dt
-from os import path
 from pathlib import Path
 from shutil import move
 from typing import Any, ClassVar, Self, override
@@ -94,21 +93,88 @@ class Target:
         preferences.
         """
         if self.directory:
-            dir_head_ = format(self.metadata, str(self.directory))
-            dir_head_ = str_sanitize(dir_head_)
-            dir_head = Path(dir_head_)
+            dir_head = self._format_directory(self.directory)
         else:
             dir_head = self.source.parent
+
         file_path = format(self.metadata, self._settings.formatting_for(self.metadata))
-        dir_tail, filename = path.split(Path(file_path))
-        filename = filename_replace(filename, self._settings.replace_after)
-        if self._settings.scene:
-            filename = str_scenify(filename)
-        if self._settings.lower:
-            filename = filename.lower()
-        filename = str_sanitize(filename)
-        directory = Path(dir_head, dir_tail)
+        dir_tail, filename = self._split_formatted_path(file_path)
+        directory = Path(dir_head, self._process_directory(dir_tail))
+        filename = self._process_filename(filename)
         return Path(directory, filename)
+
+    def _format_directory(self, directory: Path) -> Path:
+        """Format and post-process a configured directory template."""
+        formatted = Path(format(self.metadata, str(directory)))
+        process_start = self._directory_process_start(directory)
+        if process_start is None:
+            return formatted
+
+        processed_parts: list[str] = []
+        for idx, formatted_part in enumerate(formatted.parts):
+            if idx >= process_start:
+                formatted_part = self._process_path_text(formatted_part)
+            processed_parts.append(formatted_part)
+        return Path(*processed_parts)
+
+    def _directory_process_start(self, directory: Path) -> int | None:
+        """
+        Return the first configured directory component that can be transformed.
+
+        ``SettingStore`` resolves relative configured directories against the
+        current working directory. In that case, only the original relative
+        portion should receive filename-style transforms. For absolute paths
+        outside cwd, keep literal parent directories intact unless the path
+        contains a template field; this prevents ``--lower`` or ``--scene`` from
+        rewriting stable filesystem prefixes such as ``/Users`` or a mountpoint.
+        """
+        cwd_parts = Path.cwd().parts
+        if directory.parts[: len(cwd_parts)] == cwd_parts:
+            return len(cwd_parts)
+
+        template_index = self._first_template_part(directory)
+        if template_index is not None:
+            return template_index
+
+        if not directory.is_absolute():
+            return 0
+
+        return None
+
+    @staticmethod
+    def _first_template_part(directory: Path) -> int | None:
+        """Return the first component containing a format field, if one exists."""
+        for idx, part in enumerate(directory.parts):
+            if "{" in part:
+                return idx
+        return None
+
+    def _split_formatted_path(self, file_path: str) -> tuple[Path, str]:
+        """Split a formatted file template into optional directories and filename."""
+        formatted_path = Path(file_path)
+        dir_tail = formatted_path.parent
+        if str(dir_tail) == ".":
+            dir_tail = Path()
+        return dir_tail, formatted_path.name
+
+    def _process_directory(self, directory: Path) -> Path:
+        """Apply filename post-processing rules to each generated directory path."""
+        if not str(directory):
+            return Path()
+        return Path(*(self._process_path_text(part) for part in directory.parts))
+
+    def _process_filename(self, filename: str) -> str:
+        """Apply configured post-processing rules to a generated filename."""
+        return self._process_path_text(filename)
+
+    def _process_path_text(self, value: str) -> str:
+        """Apply replacement, scene, lower, and sanitize transforms in one place."""
+        value = filename_replace(value, self._settings.replace_after)
+        if self._settings.scene:
+            value = str_scenify(value)
+        if self._settings.lower:
+            value = value.lower()
+        return str_sanitize(value)
 
     def _parse(self, file_path: Path):
         path_data: dict[str, Any] = {"language": self._settings.language}

--- a/tests/e2e/test_moving.py
+++ b/tests/e2e/test_moving.py
@@ -145,6 +145,40 @@ def test_multiple_nested_directories(e2e_run, setup_test_files):
     assert expected in result.out
 
 
+@pytest.mark.usefixtures("setup_test_dir")
+def test_lower_directory(e2e_run, setup_test_files):
+    setup_test_files("Ninja Turtles (1990).mkv")
+    result = e2e_run(
+        "--batch",
+        "--lower",
+        "--movie_directory=Movies/{name[0]}",
+        "Ninja Turtles (1990).mkv",
+    )
+    expected = str(Path("/movies/t/teenage mutant ninja turtles (1990).mkv"))
+    assert result.code == 0
+    assert expected in result.out
+
+
+@pytest.mark.usefixtures("setup_test_dir")
+def test_scene_directory(e2e_run, setup_test_files):
+    setup_test_files("Ninja Turtles (1990).mkv")
+    result = e2e_run(
+        "--batch",
+        "--scene",
+        "--movie_directory=Movie Library/{name}",
+        "Ninja Turtles (1990).mkv",
+    )
+    expected = str(
+        Path(
+            "/movie.library"
+            "/teenage.mutant.ninja.turtles"
+            "/teenage.mutant.ninja.turtles.1990.mkv"
+        )
+    )
+    assert result.code == 0
+    assert expected in result.out
+
+
 @pytest.mark.omdb
 @pytest.mark.usefixtures("setup_test_dir")
 def test_format_id(e2e_run, setup_test_files):

--- a/tests/local/test_target.py
+++ b/tests/local/test_target.py
@@ -115,6 +115,94 @@ def test_destination__simple():
     pass  # TODO
 
 
+def test_destination__relative_directory_lowered():
+    """Every part of a relative configured directory receives --lower."""
+    settings = SettingStore(
+        batch=True,
+        media=MediaType.MOVIE,
+        lower=True,
+        movie_directory=Path("Movies/{name[0]}"),
+    )
+    target = Target(Path("ninja turtles (1990).mkv"), settings)
+    assert target.destination == Path("movies/n/ninja turtles (1990).mkv")
+
+
+def test_destination__absolute_directory_preserves_literal_parts():
+    """Literal parts of an absolute configured directory survive --lower."""
+    settings = SettingStore(
+        batch=True,
+        media=MediaType.MOVIE,
+        lower=True,
+        movie_directory=Path("/Media Library/Movies"),
+    )
+    target = Target(Path("ninja turtles (1990).mkv"), settings)
+    assert target.destination == Path("/Media Library/Movies/ninja turtles (1990).mkv")
+
+
+def test_destination__absolute_directory_transforms_template_parts():
+    """Template parts within an absolute configured directory are transformed."""
+    settings = SettingStore(
+        batch=True,
+        media=MediaType.MOVIE,
+        lower=True,
+        movie_directory=Path("/Media Library/{name[0]}"),
+    )
+    target = Target(Path("ninja turtles (1990).mkv"), settings)
+    assert target.destination == Path("/Media Library/n/ninja turtles (1990).mkv")
+
+
+def test_destination__format_template_directory_components_transformed():
+    """Directory components emitted by the format template are post-processed."""
+    settings = SettingStore(
+        batch=True,
+        media=MediaType.MOVIE,
+        lower=True,
+        movie_format="{name}/{name} ({year}).{extension}",
+    )
+    target = Target(Path("ninja turtles (1990).mkv"), settings)
+    assert target.destination == Path("ninja turtles/ninja turtles (1990).mkv")
+
+
+def test_destination__relative_directory_scene():
+    """--scene applies to literal and templated parts of a relative directory."""
+    settings = SettingStore(
+        batch=True,
+        media=MediaType.MOVIE,
+        scene=True,
+        movie_directory=Path("Movie Library/{name}"),
+    )
+    target = Target(Path("ninja turtles (1990).mkv"), settings)
+    assert target.destination == Path(
+        "movie.library/ninja.turtles/ninja.turtles.1990.mkv"
+    )
+
+
+def test_destination__absolute_directory_scene_preserves_literal_parts():
+    """Literal parts of an absolute configured directory survive --scene."""
+    settings = SettingStore(
+        batch=True,
+        media=MediaType.MOVIE,
+        scene=True,
+        movie_directory=Path("/Media Library/Movies"),
+    )
+    target = Target(Path("ninja turtles (1990).mkv"), settings)
+    assert target.destination == Path("/Media Library/Movies/ninja.turtles.1990.mkv")
+
+
+def test_destination__absolute_directory_scene_transforms_template_parts():
+    """Template parts within an absolute configured directory survive --scene."""
+    settings = SettingStore(
+        batch=True,
+        media=MediaType.MOVIE,
+        scene=True,
+        movie_directory=Path("/Media Library/{name}"),
+    )
+    target = Target(Path("ninja turtles (1990).mkv"), settings)
+    assert target.destination == Path(
+        "/Media Library/ninja.turtles/ninja.turtles.1990.mkv"
+    )
+
+
 def test_query():
     pass  # TODO
 

--- a/tests/local/test_target.py
+++ b/tests/local/test_target.py
@@ -124,7 +124,7 @@ def test_destination__relative_directory_lowered():
         movie_directory=Path("Movies/{name[0]}"),
     )
     target = Target(Path("ninja turtles (1990).mkv"), settings)
-    assert target.destination == Path("movies/n/ninja turtles (1990).mkv")
+    assert target.destination == Path("movies/n/ninja turtles (1990).mkv").resolve()
 
 
 def test_destination__absolute_directory_preserves_literal_parts():
@@ -160,7 +160,9 @@ def test_destination__format_template_directory_components_transformed():
         movie_format="{name}/{name} ({year}).{extension}",
     )
     target = Target(Path("ninja turtles (1990).mkv"), settings)
-    assert target.destination == Path("ninja turtles/ninja turtles (1990).mkv")
+    assert (
+        target.destination == Path("ninja turtles/ninja turtles (1990).mkv").resolve()
+    )
 
 
 def test_destination__relative_directory_scene():
@@ -172,8 +174,9 @@ def test_destination__relative_directory_scene():
         movie_directory=Path("Movie Library/{name}"),
     )
     target = Target(Path("ninja turtles (1990).mkv"), settings)
-    assert target.destination == Path(
-        "movie.library/ninja.turtles/ninja.turtles.1990.mkv"
+    assert (
+        target.destination
+        == Path("movie.library/ninja.turtles/ninja.turtles.1990.mkv").resolve()
     )
 
 
@@ -201,6 +204,21 @@ def test_destination__absolute_directory_scene_transforms_template_parts():
     assert target.destination == Path(
         "/Media Library/ninja.turtles/ninja.turtles.1990.mkv"
     )
+
+
+def test_destination__same_directory_matches_source(tmp_path, monkeypatch):
+    """`--movie_directory=.` resolves to the source path so the no-op is skippable."""
+    tmp = tmp_path.resolve()
+    monkeypatch.chdir(tmp)
+    source = tmp / "Ninja Turtles (1990).mkv"
+    source.touch()
+    settings = SettingStore(
+        batch=True,
+        media=MediaType.MOVIE,
+        movie_directory=Path("."),
+    )
+    target = Target(source, settings)
+    assert target.destination == target.source
 
 
 def test_query():

--- a/tests/local/test_target.py
+++ b/tests/local/test_target.py
@@ -206,6 +206,18 @@ def test_destination__absolute_directory_scene_transforms_template_parts():
     )
 
 
+def test_destination__parent_directory_navigation_preserved():
+    """A `..` segment in a relative directory survives sanitization."""
+    settings = SettingStore(
+        batch=True,
+        media=MediaType.MOVIE,
+        lower=True,
+        movie_directory=Path("../Movies"),
+    )
+    target = Target(Path("ninja turtles (1990).mkv"), settings)
+    assert target.destination == Path("../movies/ninja turtles (1990).mkv").resolve()
+
+
 def test_destination__same_directory_matches_source(tmp_path, monkeypatch):
     """`--movie_directory=.` resolves to the source path so the no-op is skippable."""
     tmp = tmp_path.resolve()


### PR DESCRIPTION
## Summary
- Apply the existing filename post-processing pipeline (`replace_after`, `--scene`, `--lower`, and sanitization) to generated directory components.
- Process relative configured directories while preserving stable absolute path prefixes.
- Process directory components emitted by `movie_format` / `episode_format`, so nested template paths behave consistently with filenames.

Addresses #184.

## Tests
- `python3.12 -m venv .venv`
- `python -m pip install -e . pytest`
- `python -m pip install 'ruff~=0.15.12'`
- `pytest tests/local -q`
- `ruff check mnamer/target.py`
- `ruff format --check mnamer/target.py`