### PR TITLE
Fix CI

### DIFF
--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -1,19 +1,28 @@
 name: Init
 description: Sets up the environment for build, lint, and test jobs
 
+inputs:
+  save-cache:
+    description: Whether to save the uv cache after the job
+    required: false
+    default: "true"
+
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6.2.0
       with:
-        python-version: '3.12'
+        python-version: "3.12"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
-        cache-dependency-glob: "**/pyproject.toml"
+        save-cache: ${{ inputs.save-cache }}
+        cache-dependency-glob: |
+          **/pyproject.toml
+          **/uv.lock
 
     - name: Install dependencies
       shell: sh
-      run: uv sync --locked --dev
+      run: uv sync --python 3.12 --locked --dev

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -22,6 +22,11 @@ inputs:
     required: false
     default: "false"
 
+  codecov-token:
+    description: Token for uploading coverage to Codecov
+    required: false
+    default: ""
+
 runs:
   using: composite
   steps:
@@ -29,7 +34,7 @@ runs:
       if: inputs.local == 'true'
       run: >-
         uv run pytest
-        -m local
+        -m "local"
         --durations=10
         --cov=./
         --cov-append
@@ -63,17 +68,12 @@ runs:
         --cov-report=xml
       shell: sh
 
-    - name: Printing E2E Logs
-      run: cat e2e.log
-      shell: sh
-      if: >-
-        inputs.e2e == 'true'
-        && failure()
-
     - name: Reporting Coverage Statistics
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6.0.1
       if: >-
         success()
         && inputs.coverage == 'true'
         && github.event_name == 'push'
         && github.ref == 'refs/heads/main'
+      with:
+        token: ${{ inputs.codecov-token }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/init
+        with:
+          save-cache: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
       - name: Linting
         uses: ./.github/actions/lint
@@ -22,21 +24,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/init
-
-      - name: Testing (contributor)
-        uses: ./.github/actions/test
-        if: github.actor != 'dependabot[bot]'
-        env:
-          API_KEY_OMDB: ${{ secrets.API_KEY_OMDB }}
         with:
-          local: true
-          network: true
-          e2e: true
-          coverage: false
+          save-cache: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
-      - name: Testing (dependabot)
+      - name: Testing (PR)
         uses: ./.github/actions/test
-        if: github.actor == 'dependabot[bot]'
         with:
           local: true
           network: false

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,8 +32,8 @@ jobs:
           API_KEY_OMDB: ${{ secrets.API_KEY_OMDB }}
         with:
           local: true
-          network: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          e2e: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          network: ${{ github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+          e2e: ${{ github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
           coverage: true
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,14 +26,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/init
-      - uses: ./.github/actions/test
+      - name: Testing
+        uses: ./.github/actions/test
         env:
           API_KEY_OMDB: ${{ secrets.API_KEY_OMDB }}
         with:
           local: true
-          network: true
-          e2e: true
+          network: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          e2e: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           coverage: true
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   publish-pypi:
     if: >-


### PR DESCRIPTION
Update CI so PRs run local tests only, while pushes to main and scheduled runs execute the full test suite.

This keeps network and e2e tests scoped to main merges/direct pushes plus the periodic scheduled check, avoiding flaky provider-backed tests on ordinary PR validation.