### PR TITLE
Restrict GitHub Actions token permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish-pypi:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,6 +2,9 @@ name: pr
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,6 +11,9 @@ on:
       - published
       - prereleased
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -50,6 +53,9 @@ jobs:
     secrets:
       inherit
 
+    permissions:
+      contents: read
+
     uses: ./.github/workflows/publish.yml
 
   publish-docker-main:
@@ -64,6 +70,10 @@ jobs:
 
     secrets:
       inherit
+
+    permissions:
+      contents: read
+      packages: write
 
     uses: ./.github/workflows/publish-docker.yml
     with:
@@ -84,6 +94,10 @@ jobs:
 
     secrets:
       inherit
+
+    permissions:
+      contents: read
+      packages: write
 
     uses: ./.github/workflows/publish-docker.yml
     with:


### PR DESCRIPTION
## Summary
- add explicit read-only GITHUB_TOKEN permissions to publish, pull request, and push workflows
- grant packages: write only to Docker publish caller jobs that push to GHCR
- remediate open CodeQL actions/missing-workflow-permissions alerts