### PR TITLE
Mock provider APIs in e2e tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,6 @@
 .venv
 build
 dist
+venv
 *.egg-info
 __pycache__

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,5 +32,5 @@ jobs:
         with:
           local: true
           network: false
-          e2e: false
+          e2e: true
           coverage: false

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           local: true
           network: ${{ github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
-          e2e: ${{ github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+          e2e: true
           coverage: true
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__/
 *.log
 *.py[cod]
 *$py.class
+.venv/
 build
 coverage.xml
 demo/
@@ -22,4 +23,4 @@ MANIFEST
 mnamer/__version__.py
 playground.py
 testing/test_files_*
-venv*
+venv/

--- a/mnamer/endpoints.py
+++ b/mnamer/endpoints.py
@@ -26,12 +26,15 @@ MAX_RETRIES = 5
 class OmdbSearchEntry(TypedDict):
     imdb_id: str
     year: str
+    type: str
     title: NotRequired[str]
 
 
 class OmdbTitleResponse(TypedDict):
     title: str
     year: str
+    response: str
+    type: str
     released: NotRequired[str]
     plot: NotRequired[str]
     imdb_id: str
@@ -47,6 +50,7 @@ class OmdbSearchResponse(TypedDict):
 class TmdbSearchEntry(TypedDict):
     id: int
     title: str
+    original_title: str
     release_date: NotRequired[str]
     overview: NotRequired[str]
 
@@ -67,6 +71,8 @@ class TmdbSearchResponse(TypedDict):
 
 class TvdbLinks(TypedDict):
     last: int
+    next: int | None
+    prev: int | None
 
 
 class TvdbSeriesData(TypedDict):
@@ -79,6 +85,7 @@ class TvdbSeriesResponse(TypedDict):
 
 
 class TvdbEpisodeEntry(TypedDict):
+    id: int
     first_aired: str
     aired_episode_number: int
     aired_season: int
@@ -93,6 +100,7 @@ class TvdbEpisodesResponse(TypedDict):
 
 class TvdbSearchEntry(TypedDict):
     id: int
+    series_name: str
 
 
 class TvdbSearchResponse(TypedDict):
@@ -115,6 +123,7 @@ class TvMazeSearchEntry(TypedDict):
 
 
 class TvMazeEpisode(TypedDict):
+    id: int
     airdate: str | None
     number: int | None
     season: int
@@ -330,13 +339,22 @@ def tvdb_refresh_token(token: str) -> str:
     Online docs: api.thetvdb.com/swagger#!/Authentication/get_refresh_token.
     """
     url = "https://api.thetvdb.com/refresh_token"
-    headers = {"Authorization": f"Bearer {token}"}
+    headers = _tvdb_headers(token)
     status, content = request_json(url, headers=headers, cache=False)
     if status == 401:
         raise MnamerException("invalid token")
     elif status != 200 or not content.get("token"):  # pragma: no cover
         raise MnamerNetworkException("TVDb down or unavailable?")
     return content["token"]
+
+
+def _tvdb_headers(token: str, language: Language | None = None) -> dict[str, str]:
+    if token.count(".") != 2:
+        raise MnamerException("invalid token")
+    headers = {"Authorization": f"Bearer {token}"}
+    if language:
+        headers["Accept-Language"] = language.a2
+    return headers
 
 
 def tvdb_episodes_id(
@@ -352,9 +370,7 @@ def tvdb_episodes_id(
     """
     Language.ensure_valid_for_tvdb(language)
     url = f"https://api.thetvdb.com/episodes/{id_tvdb}"
-    headers = {"Authorization": f"Bearer {token}"}
-    if language:
-        headers["Accept-Language"] = language.a2
+    headers = _tvdb_headers(token, language)
     status, content = request_json(
         url, headers=headers, cache=cache is True and language is None
     )
@@ -384,9 +400,7 @@ def tvdb_series_id(
     """
     Language.ensure_valid_for_tvdb(language)
     url = f"https://api.thetvdb.com/series/{id_tvdb}"
-    headers = {"Authorization": f"Bearer {token}"}
-    if language:
-        headers["Accept-Language"] = language.a2
+    headers = _tvdb_headers(token, language)
     status, content = request_json(
         url, headers=headers, cache=cache is True and language is None
     )
@@ -417,9 +431,7 @@ def tvdb_series_id_episodes(
     """
     Language.ensure_valid_for_tvdb(language)
     url = f"https://api.thetvdb.com/series/{id_tvdb}/episodes"
-    headers = {"Authorization": f"Bearer {token}"}
-    if language:
-        headers["Accept-Language"] = language.a2
+    headers = _tvdb_headers(token, language)
     parameters: dict[str, Any] = {"page": page}
     status, content = request_json(
         url, parameters, headers=headers, cache=cache is True and language is None
@@ -452,9 +464,7 @@ def tvdb_series_id_episodes_query(
     """
     Language.ensure_valid_for_tvdb(language)
     url = f"https://api.thetvdb.com/series/{id_tvdb}/episodes/query"
-    headers = {"Authorization": f"Bearer {token}"}
-    if language:
-        headers["Accept-Language"] = language.a2
+    headers = _tvdb_headers(token, language)
     parameters: dict[str, Any] = {
         "airedSeason": season,
         "airedEpisode": episode,
@@ -497,9 +507,7 @@ def tvdb_search_series(
         "imdbId": id_imdb,
         "zap2itId": id_zap2it,
     }
-    headers = {"Authorization": f"Bearer {token}"}
-    if language:
-        headers["Accept-Language"] = language.a2
+    headers = _tvdb_headers(token, language)
     status, content = request_json(
         url, parameters, headers=headers, cache=cache is True and language is None
     )

--- a/mnamer/frontends.py
+++ b/mnamer/frontends.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import override
 
 from mnamer import tty
-from mnamer.const import SYSTEM, USAGE, VERSION  # pyright: ignore
+from mnamer.const import SYSTEM, USAGE, VERSION
 from mnamer.exceptions import (
     MnamerAbortException,
     MnamerException,

--- a/mnamer/providers.py
+++ b/mnamer/providers.py
@@ -44,8 +44,7 @@ class Provider[M: Metadata](ABC):
         """Initializes the provider."""
         if api_key:
             self.api_key = api_key
-        if cache:
-            self.cache = cache
+        self.cache = cache
 
     @classmethod
     def from_settings(cls, settings: SettingStore) -> Self:
@@ -141,7 +140,7 @@ class Omdb(Provider[MetadataMovie]):
             synopsis=response.get("plot"),
             id_imdb=response["imdb_id"],
         )
-        if meta.synopsis == "N/A":
+        if meta.synopsis and meta.synopsis.upper() == "N/A":
             meta.synopsis = None
         yield meta
 

--- a/mnamer/utils.py
+++ b/mnamer/utils.py
@@ -3,7 +3,7 @@
 import datetime as dt
 import json
 import re
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import nullcontext
 from os import walk
 from os.path import exists, expanduser, expandvars, getsize, splitdrive, splitext
@@ -18,7 +18,7 @@ from mnamer.const import CACHE_PATH, CURRENT_YEAR, SUBTITLE_CONTAINERS
 
 
 def clean_dict(
-    target_dict: dict[str, Any], whitelist: Iterable[str] | None = None
+    target_dict: Mapping[Any, Any], whitelist: Iterable[Any] | None = None
 ) -> dict[str, str]:
     """Convenience function that removes a dicts keys that have falsy values."""
     return {
@@ -121,7 +121,7 @@ def fn_pipe[T](*fn_list: Callable[[T], T]) -> Callable[[T], T]:
     return resolver
 
 
-def format_dict(body: dict[str, Any]) -> str:
+def format_dict(body: Mapping[Any, Any]) -> str:
     """
     Formats a dictionary into a multi-line bulleted string of key-value pairs.
     """
@@ -248,7 +248,7 @@ def request_json(
     url: str,
     parameters: dict[str, Any] | list[tuple[str, Any]] | None = None,
     body: dict[str, Any] | None = None,
-    headers: dict[str, str] | None = None,
+    headers: dict[str, Any] | None = None,
     cache: bool = True,
 ) -> tuple[int, Any]:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "babelfish~=0.6.1",
     "guessit~=3.8.0",
     "requests>=2.33.1,<2.35.0",
-    "requests-cache~=1.3.1",
+    "requests-cache~=1.3.2",
     "setuptools-scm>=10.0.0",
     "teletype~=1.3.4",
 ]
@@ -38,6 +38,7 @@ dev = [
     "mypy>=2.0",
     "pylint>=4.0",
     "pytest-cov>=7.0",
+    "pytest-mock>=3.15.1",
     "pytest-rerunfailures>=16.0",
     "pytest>=9.0",
     "ruff~=0.15.12",
@@ -75,13 +76,25 @@ line-ending = "auto"
 [tool.pyright]
 pythonVersion = "3.12"
 include = ["mnamer"]
-exclude = ["playground.py", ".venv", "venv", "build", "dist", "tests"]
-venv = "venv"
+exclude = ["playground.py", ".venv", "venv", "build", "dist"]
+venvPath = "."
+venv = ".venv"
 reportAny = false
 reportExplicitAny = false
 reportGeneralTypeIssues = "information"
 reportIgnoreCommentWithoutRule = false
+reportImplicitStringConcatenation = false
+reportMissingParameterType = false
 reportMissingTypeStubs = false
+reportPrivateLocalImportUsage = false
+reportPrivateUsage = false
+reportUnannotatedClassAttribute = false
+reportUnknownArgumentType = false
+reportUnknownMemberType = false
+reportUnknownParameterType = false
+reportUnknownVariableType = false
+reportUnusedCallResult = false
+reportUnusedParameter = false
 
 [tool.ruff.lint.isort]
 known-first-party = ["mnamer"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 addopts = --tb=short
+filterwarnings =
+    ignore:Transitional processing has been removed from UTS #46.*:DeprecationWarning:url_normalize\.normalize_host
 
 markers =
     e2e

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,8 +1,9 @@
 import datetime as dt
 from collections.abc import Mapping, Set
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, NotRequired, TypedDict
 
 from mnamer.const import SUBTITLE_CONTAINERS
+from mnamer.endpoints import TvdbEpisodeEntry, TvMazeEpisode, TvMazeShow
 from mnamer.language import Language
 from mnamer.types import ProviderType
 
@@ -42,7 +43,49 @@ DEFAULT_SETTINGS = {
 
 JUNK_TEXT = "blablablabla"
 
-EPISODE_META = {
+
+class EpisodeMeta(TypedDict):
+    date: dt.date
+    episode: int
+    id_imdb: str
+    id_tvdb: int
+    id_tvmaze: int
+    media: str
+    season: int
+    series: str
+    title: str
+
+
+class MovieFixture(TypedDict):
+    id_imdb: str
+    id_tmdb: str
+    name: str
+    year: str
+
+
+class MovieMeta(TypedDict):
+    id_imdb: str
+    id_tmdb: int
+    media: str
+    name: str
+    year: int
+
+
+class E2EEpisodeFixture(TypedDict):
+    date: str
+    episode: int
+    id_tvdb: str
+    overview: str
+    season: int
+    series: str
+    title: str
+    alias: NotRequired[str]
+    id_imdb: NotRequired[str]
+    id_tvmaze: NotRequired[str]
+    summary: NotRequired[str]
+
+
+EPISODE_META: dict[str, EpisodeMeta] = {
     "The Walking Dead": {
         "date": dt.date(2015, 2, 22),
         "episode": 11,
@@ -78,28 +121,269 @@ EPISODE_META = {
     },
 }
 
-MOVIE_META = {
+MOVIE_FIXTURES: dict[str, MovieFixture] = {
     "Idiocracy": {
         "id_imdb": "tt0387808",
-        "id_tmdb": 7512,
-        "media": "movie",
+        "id_tmdb": "7512",
         "name": "Idiocracy",
-        "year": 2006,
+        "year": "2006-09-01",
     },
     "Citizen Kane": {
         "id_imdb": "tt0033467",
-        "id_tmdb": 15,
-        "media": "movie",
+        "id_tmdb": "15",
         "name": "Citizen Kane",
-        "year": 1941,
+        "year": "1941-05-01",
     },
     "Les Misérables": {
         "id_imdb": "tt10199590",
-        "id_tmdb": 586863,
-        "media": "movie",
+        "id_tmdb": "586863",
         "name": "Les Misérables",
-        "year": 2019,
+        "year": "2019-11-20",
     },
+    "Aladdin 1992": {
+        "name": "Aladdin",
+        "year": "1992-11-25",
+        "id_imdb": "tt0103639",
+        "id_tmdb": "812",
+    },
+    "Aladdin 2019": {
+        "name": "Aladdin",
+        "year": "2019-05-24",
+        "id_imdb": "tt6139732",
+        "id_tmdb": "420817",
+    },
+    "Avengers Infinity War": {
+        "name": "Avengers Infinity War",
+        "year": "2018-04-27",
+        "id_imdb": "tt4154756",
+        "id_tmdb": "299536",
+    },
+    "Harry Potter and the Sorcerer's Stone": {
+        "name": "Harry Potter and the Sorcerer's Stone",
+        "year": "2001-11-16",
+        "id_imdb": "tt0241527",
+        "id_tmdb": "671",
+    },
+    "Joker": {
+        "name": "Joker",
+        "year": "2019-10-04",
+        "id_imdb": "tt7286456",
+        "id_tmdb": "475557",
+    },
+    "Kill Bill Vol. 1": {
+        "name": "Kill Bill Vol. 1",
+        "year": "2003-10-10",
+        "id_imdb": "tt0266697",
+        "id_tmdb": "24",
+    },
+    "Pride & Prejudice": {
+        "name": "Pride & Prejudice",
+        "year": "2005-11-23",
+        "id_imdb": "tt0414387",
+        "id_tmdb": "4348",
+    },
+    "Saw": {
+        "name": "Saw",
+        "year": "2004-10-29",
+        "id_imdb": "tt0387564",
+        "id_tmdb": "176",
+    },
+    "Shape of Water": {
+        "name": "Shape of Water",
+        "year": "2017-12-22",
+        "id_imdb": "tt5580390",
+        "id_tmdb": "399055",
+    },
+    "Teenage Mutant Ninja Turtles": {
+        "name": "Teenage Mutant Ninja Turtles",
+        "year": "1990-03-30",
+        "id_imdb": "tt0100758",
+        "id_tmdb": "1498",
+    },
+    "The Goonies": {
+        "name": "The Goonies",
+        "year": "1985-06-07",
+        "id_imdb": "tt0089218",
+        "id_tmdb": "9340",
+    },
+}
+
+
+def _movie_meta_from_fixture(fixture: MovieFixture) -> MovieMeta:
+    return {
+        "id_imdb": fixture["id_imdb"],
+        "id_tmdb": int(fixture["id_tmdb"]),
+        "media": "movie",
+        "name": fixture["name"],
+        "year": int(fixture["year"][:4]),
+    }
+
+
+MOVIE_META: dict[str, MovieMeta] = {
+    key: _movie_meta_from_fixture(MOVIE_FIXTURES[key])
+    for key in ("Idiocracy", "Citizen Kane", "Les Misérables")
+}
+
+E2E_MOVIE_FIXTURES: list[MovieFixture] = [
+    MOVIE_FIXTURES[key]
+    for key in (
+        "Aladdin 1992",
+        "Aladdin 2019",
+        "Avengers Infinity War",
+        "Harry Potter and the Sorcerer's Stone",
+        "Joker",
+        "Kill Bill Vol. 1",
+        "Pride & Prejudice",
+        "Saw",
+        "Shape of Water",
+        "Teenage Mutant Ninja Turtles",
+        "The Goonies",
+    )
+]
+
+E2E_MOVIE_TITLE_ALIASES: dict[str, list[str]] = {
+    "aladdin": ["Aladdin"],
+    "avengers infinity war": ["Avengers Infinity War"],
+    "goonies": ["The Goonies"],
+    "harry potter and the sorcerer s stone": ["Harry Potter and the Sorcerer's Stone"],
+    "kill bill": ["Kill Bill Vol. 1"],
+    "kill bill vol 1": ["Kill Bill Vol. 1"],
+    "ninja turtles": ["Teenage Mutant Ninja Turtles"],
+    "pride prejudice": ["Pride & Prejudice"],
+    "saw": ["Saw"],
+    "teenage mutant ninja turtles": ["Teenage Mutant Ninja Turtles"],
+    "the goonies": ["The Goonies"],
+}
+
+E2E_EPISODE_FIXTURES: dict[str, E2EEpisodeFixture] = {
+    "Archer": {
+        "alias": "archer",
+        "date": "2019-07-10",
+        "episode": 7,
+        "id_imdb": "tt1486217",
+        "id_tvdb": "110381",
+        "id_tvmaze": "143",
+        "overview": "Archer and the crew meet pirates.",
+        "season": 10,
+        "series": "Archer",
+        "summary": "Archer and the crew meet pirates.",
+        "title": "Space Pirates",
+    },
+    "Dexter": {
+        "date": "2006-10-29",
+        "episode": 5,
+        "id_tvdb": "79349",
+        "overview": "Dexter stalks another killer.",
+        "season": 1,
+        "series": "Dexter",
+        "title": "Love American Style",
+    },
+    "Game of Thrones": {
+        "alias": "game of thrones",
+        "date": "2011-05-15",
+        "episode": 5,
+        "id_imdb": "tt0944947",
+        "id_tvdb": "121361",
+        "id_tvmaze": "82",
+        "overview": "Ned refuses an order from the king.",
+        "season": 1,
+        "series": "Game of Thrones",
+        "summary": "Ned refuses an order from the king.",
+        "title": "The Wolf and the Lion",
+    },
+    "Lost": {
+        "alias": "lost",
+        "date": "2004-09-22",
+        "episode": 1,
+        "id_imdb": "tt0636289",
+        "id_tvdb": "73739",
+        "id_tvmaze": "123",
+        "overview": "The survivors of Oceanic Flight 815 adjust to the island.",
+        "season": 1,
+        "series": "Lost",
+        "summary": "The survivors of Oceanic Flight 815 adjust to the island.",
+        "title": "Pilot (1)",
+    },
+    "O.J.: Made in America": {
+        "alias": "o j made in america",
+        "date": "2016-06-14",
+        "episode": 3,
+        "id_imdb": "tt5275892",
+        "id_tvdb": "314544",
+        "id_tvmaze": "2578",
+        "overview": "The trial begins.",
+        "season": 1,
+        "series": "O.J.: Made in America",
+        "summary": "The trial begins.",
+        "title": "Part Three",
+    },
+    "South Park": {
+        "alias": "south park",
+        "date": "1997-08-13",
+        "episode": 1,
+        "id_tvdb": "75897",
+        "overview": "The original South Park short.",
+        "season": 0,
+        "series": "South Park",
+        "title": "The Spirit of Christmas",
+    },
+}
+
+E2E_TVMAZE_SHOW_FIXTURES: dict[str, TvMazeShow] = {
+    fixture["id_tvmaze"]: {
+        "id": int(str(fixture["id_tvmaze"])),
+        "name": fixture["series"],
+        "externals": {
+            "thetvdb": int(str(fixture["id_tvdb"])),
+            "imdb": fixture.get("id_imdb"),
+        },
+    }
+    for fixture in E2E_EPISODE_FIXTURES.values()
+    if "id_tvmaze" in fixture
+}
+
+E2E_TVMAZE_SERIES_ALIASES: dict[str, str] = {
+    fixture["alias"]: fixture["id_tvmaze"]
+    for fixture in E2E_EPISODE_FIXTURES.values()
+    if "alias" in fixture and "id_tvmaze" in fixture
+}
+
+E2E_TVMAZE_EPISODE_FIXTURES: dict[tuple[str, int, int], TvMazeEpisode] = {
+    (fixture["id_tvmaze"], fixture["season"], fixture["episode"]): {
+        "id": int(str(fixture["id_tvmaze"])),
+        "airdate": fixture["date"],
+        "number": fixture["episode"],
+        "season": fixture["season"],
+        "name": fixture["title"],
+        "summary": fixture.get("summary"),
+    }
+    for fixture in E2E_EPISODE_FIXTURES.values()
+    if "id_tvmaze" in fixture
+}
+
+E2E_TVDB_SERIES_FIXTURES: dict[str, str] = {
+    fixture["id_tvdb"]: fixture["series"]
+    for fixture in E2E_EPISODE_FIXTURES.values()
+    if "id_tvdb" in fixture
+}
+
+E2E_TVDB_SERIES_ALIASES: dict[str, list[str]] = {
+    fixture["alias"]: [fixture["id_tvdb"]]
+    for fixture in E2E_EPISODE_FIXTURES.values()
+    if fixture.get("series") in {"Archer", "South Park"} and "alias" in fixture
+}
+
+E2E_TVDB_EPISODE_FIXTURES: dict[tuple[str, int, int], TvdbEpisodeEntry] = {
+    (fixture["id_tvdb"], fixture["season"], fixture["episode"]): {
+        "id": int(str(fixture["id_tvdb"])),
+        "first_aired": fixture["date"],
+        "aired_episode_number": fixture["episode"],
+        "aired_season": fixture["season"],
+        "overview": fixture.get("overview"),
+        "episode_name": fixture["title"],
+    }
+    for fixture in E2E_EPISODE_FIXTURES.values()
+    if "id_tvdb" in fixture
 }
 
 TEST_DATE = dt.date(2010, 12, 9)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,15 +1,45 @@
+import datetime as dt
+import re
 import sys
+from collections.abc import Callable
 from os import chdir
 from pathlib import Path
 
 import pytest
+from pytest_mock import MockerFixture
 from teletype.io import strip_format
 
-from mnamer.exceptions import MnamerException
+from mnamer.endpoints import (
+    OmdbSearchResponse,
+    OmdbTitleResponse,
+    TmdbMovieResponse,
+    TmdbSearchEntry,
+    TmdbSearchResponse,
+    TvdbEpisodeEntry,
+    TvdbEpisodesResponse,
+    TvdbSearchEntry,
+    TvdbSearchResponse,
+    TvdbSeriesResponse,
+    TvMazeEpisode,
+    TvMazeSearchEntry,
+    TvMazeShow,
+)
+from mnamer.exceptions import MnamerException, MnamerNotFoundException
 from mnamer.frontends import Cli
 from mnamer.setting_store import SettingStore
 from mnamer.target import Target
-from tests import E2EResult
+from tests import (
+    E2E_MOVIE_FIXTURES,
+    E2E_MOVIE_TITLE_ALIASES,
+    E2E_TVDB_EPISODE_FIXTURES,
+    E2E_TVDB_SERIES_ALIASES,
+    E2E_TVDB_SERIES_FIXTURES,
+    E2E_TVMAZE_EPISODE_FIXTURES,
+    E2E_TVMAZE_SERIES_ALIASES,
+    E2E_TVMAZE_SHOW_FIXTURES,
+    E2EResult,
+    MovieFixture,
+)
 
 # Move up to root directory if run from subdirectory
 cwd = Path().resolve()
@@ -23,18 +53,307 @@ E2E_LOG = Path().absolute() / "e2e.log"
 E2E_LOG.open("w").close()
 
 
+def _key(value: object) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", str(value).lower()).strip()
+
+
+def _movie_year(movie: MovieFixture) -> int:
+    return int(movie["year"][:4])
+
+
+def _movie_by_tmdb_id(id_tmdb: object) -> MovieFixture:
+    for movie in E2E_MOVIE_FIXTURES:
+        if movie["id_tmdb"] == str(id_tmdb):
+            return movie
+    raise MnamerNotFoundException
+
+
+def _movie_by_imdb_id(id_imdb: object) -> MovieFixture:
+    for movie in E2E_MOVIE_FIXTURES:
+        if movie["id_imdb"] == str(id_imdb):
+            return movie
+    raise MnamerNotFoundException
+
+
+def _movies_by_title(
+    title: str | None, year: int | str | None = None
+) -> list[MovieFixture]:
+    names = E2E_MOVIE_TITLE_ALIASES.get(_key(title), [])
+    matches = [movie for movie in E2E_MOVIE_FIXTURES if movie["name"] in names]
+    if year is not None:
+        matches = [movie for movie in matches if _movie_year(movie) == int(year)]
+    if not matches:
+        raise MnamerNotFoundException
+    return matches
+
+
+def _tmdb_movie(movie: MovieFixture) -> TmdbMovieResponse:
+    return {
+        "id": int(movie["id_tmdb"]),
+        "title": movie["name"],
+        "release_date": movie["year"],
+        "overview": f"{movie['name']} overview.",
+        "imdb_id": movie["id_imdb"],
+    }
+
+
+def _tmdb_search_movie(movie: MovieFixture) -> TmdbSearchEntry:
+    return {
+        "id": int(movie["id_tmdb"]),
+        "title": movie["name"],
+        "original_title": movie["name"],
+        "release_date": movie["year"],
+        "overview": f"{movie['name']} overview.",
+    }
+
+
+def _omdb_movie(movie: MovieFixture) -> OmdbTitleResponse:
+    return {
+        "title": movie["name"],
+        "year": movie["year"][:4],
+        "response": "True",
+        "type": "movie",
+        "released": f"01 Jan {movie['year'][:4]}",
+        "plot": f"{movie['name']} plot.",
+        "imdb_id": movie["id_imdb"],
+    }
+
+
+def _tvmaze_show_by_query(series: object) -> TvMazeShow:
+    try:
+        return E2E_TVMAZE_SHOW_FIXTURES[E2E_TVMAZE_SERIES_ALIASES[_key(series)]]
+    except KeyError as e:
+        raise MnamerNotFoundException from e
+
+
+def _tvmaze_show_by_id(id_tvmaze: object) -> TvMazeShow:
+    try:
+        return E2E_TVMAZE_SHOW_FIXTURES[str(id_tvmaze)]
+    except KeyError as e:
+        raise MnamerNotFoundException from e
+
+
+def _tvmaze_episode(id_tvmaze: object, season: int, episode: int) -> TvMazeEpisode:
+    try:
+        return E2E_TVMAZE_EPISODE_FIXTURES[(str(id_tvmaze), season, episode)]
+    except KeyError as e:
+        raise MnamerNotFoundException from e
+
+
+def _tvdb_episode(id_tvdb: object, season: int, episode: int) -> TvdbEpisodeEntry:
+    try:
+        return E2E_TVDB_EPISODE_FIXTURES[(str(id_tvdb), season, episode)]
+    except KeyError as e:
+        raise MnamerNotFoundException from e
+
+
 @pytest.fixture(autouse=True)
-def reset_args():
+def mock_provider_endpoints(mocker: MockerFixture) -> None:
+    """Mocks provider endpoint calls so E2E tests do not use network APIs."""
+
+    def tmdb_movies(
+        _api_key: str,
+        id_tmdb: object,
+        _language: object | None = None,
+        cache: bool = True,
+    ) -> TmdbMovieResponse:
+        return _tmdb_movie(_movie_by_tmdb_id(id_tmdb))
+
+    def tmdb_search_movies(
+        _api_key: str,
+        title: str,
+        year: int | str | None = None,
+        language: object | None = None,
+        region: str | None = None,
+        adult: bool = False,
+        page: int = 1,
+        cache: bool = True,
+    ) -> TmdbSearchResponse:
+        movies = _movies_by_title(title, year)
+        if page > 1:
+            movies = []
+        return {
+            "results": [_tmdb_search_movie(movie) for movie in movies],
+            "total_pages": 1,
+            "total_results": len(movies),
+        }
+
+    def omdb_title(
+        api_key: str,
+        id_imdb: str | None = None,
+        media: str | None = None,
+        title: str | None = None,
+        season: int | None = None,
+        episode: int | None = None,
+        year: int | str | None = None,
+        plot: str | None = None,
+        cache: bool = True,
+    ) -> OmdbTitleResponse:
+        movie = (
+            _movie_by_imdb_id(id_imdb) if id_imdb else _movies_by_title(title, year)[0]
+        )
+        return _omdb_movie(movie)
+
+    def omdb_search(
+        api_key: str,
+        query: str,
+        year: int | str | None = None,
+        media: str | None = None,
+        page: int = 1,
+        cache: bool = True,
+    ) -> OmdbSearchResponse:
+        movies = _movies_by_title(query, year)
+        if page > 1:
+            raise MnamerNotFoundException
+        return {
+            "search": [
+                {
+                    "imdb_id": movie["id_imdb"],
+                    "title": movie["name"],
+                    "year": movie["year"][:4],
+                    "type": "movie",
+                }
+                for movie in movies
+            ],
+            "total_results": str(len(movies)),
+        }
+
+    def tvdb_search_series(
+        _token: str, series: str | None = None, **_kwargs: object
+    ) -> TvdbSearchResponse:
+        try:
+            ids = E2E_TVDB_SERIES_ALIASES[_key(series)]
+        except KeyError as e:
+            raise MnamerNotFoundException from e
+        data: list[TvdbSearchEntry] = [
+            {"id": int(id_tvdb), "series_name": E2E_TVDB_SERIES_FIXTURES[id_tvdb]}
+            for id_tvdb in ids
+        ]
+        return {"data": data}
+
+    def tvdb_series_id(
+        _token: str, id_tvdb: object, **_kwargs: object
+    ) -> TvdbSeriesResponse:
+        try:
+            series_name = E2E_TVDB_SERIES_FIXTURES[str(id_tvdb)]
+        except KeyError as e:
+            raise MnamerNotFoundException from e
+        return {"data": {"id": int(str(id_tvdb)), "series_name": series_name}}
+
+    def tvdb_series_id_episodes_query(
+        _token: str,
+        id_tvdb: object,
+        episode: int | None = None,
+        season: int | None = None,
+        page: int = 1,
+        **_kwargs: object,
+    ) -> TvdbEpisodesResponse:
+        if page > 1:
+            raise MnamerNotFoundException
+        if season is None or episode is None:
+            data = [
+                entry
+                for (
+                    entry_id,
+                    _entry_season,
+                    _entry_episode,
+                ), entry in E2E_TVDB_EPISODE_FIXTURES.items()
+                if entry_id == str(id_tvdb)
+            ]
+        else:
+            data = [_tvdb_episode(id_tvdb, season, episode)]
+        return {"data": data, "links": {"last": 1, "next": None, "prev": None}}
+
+    def tvmaze_show_search(series: str, **_kwargs: object) -> list[TvMazeSearchEntry]:
+        show = _tvmaze_show_by_query(series)
+        return [{"show": show}]
+
+    def tvmaze_episode_by_number(
+        id_tvmaze: object, season: int, episode: int, **_kwargs: object
+    ) -> TvMazeEpisode:
+        return _tvmaze_episode(id_tvmaze, season, episode)
+
+    def tvmaze_show(id_tvmaze: object, **_kwargs: object) -> TvMazeShow:
+        return _tvmaze_show_by_id(id_tvmaze)
+
+    def tvmaze_show_lookup(**kwargs: object) -> TvMazeShow:
+        id_tvdb = str(kwargs.get("id_tvdb"))
+        for show in E2E_TVMAZE_SHOW_FIXTURES.values():
+            externals = show["externals"]
+            if str(externals.get("thetvdb")) == id_tvdb:
+                return show
+        raise MnamerNotFoundException
+
+    def tvmaze_show_episodes_list(
+        id_tvmaze: object, **_kwargs: object
+    ) -> list[TvMazeEpisode]:
+        episodes = [
+            entry
+            for (
+                entry_id,
+                _season,
+                _episode,
+            ), entry in E2E_TVMAZE_EPISODE_FIXTURES.items()
+            if entry_id == str(id_tvmaze)
+        ]
+        if not episodes:
+            raise MnamerNotFoundException
+        return episodes
+
+    def tvmaze_episodes_by_date(
+        id_tvmaze: object, air_date: dt.date | str, **_kwargs: object
+    ) -> list[TvMazeEpisode]:
+        episodes = [
+            entry
+            for entry in tvmaze_show_episodes_list(id_tvmaze)
+            if entry["airdate"] == str(air_date)
+        ]
+        if not episodes:
+            raise MnamerNotFoundException
+        return episodes
+
+    mocker.patch("mnamer.providers.tmdb_movies", side_effect=tmdb_movies)
+    mocker.patch("mnamer.providers.tmdb_search_movies", side_effect=tmdb_search_movies)
+    mocker.patch("mnamer.providers.omdb_title", side_effect=omdb_title)
+    mocker.patch("mnamer.providers.omdb_search", side_effect=omdb_search)
+    mocker.patch("mnamer.providers.tvdb_login", return_value="token")
+    mocker.patch("mnamer.providers.tvdb_search_series", side_effect=tvdb_search_series)
+    mocker.patch("mnamer.providers.tvdb_series_id", side_effect=tvdb_series_id)
+    mocker.patch(
+        "mnamer.providers.tvdb_series_id_episodes_query",
+        side_effect=tvdb_series_id_episodes_query,
+    )
+    mocker.patch("mnamer.providers.tvmaze_show_search", side_effect=tvmaze_show_search)
+    mocker.patch(
+        "mnamer.providers.tvmaze_episode_by_number",
+        side_effect=tvmaze_episode_by_number,
+    )
+    mocker.patch("mnamer.providers.tvmaze_show", side_effect=tvmaze_show)
+    mocker.patch("mnamer.providers.tvmaze_show_lookup", side_effect=tvmaze_show_lookup)
+    mocker.patch(
+        "mnamer.providers.tvmaze_show_episodes_list",
+        side_effect=tvmaze_show_episodes_list,
+    )
+    mocker.patch(
+        "mnamer.providers.tvmaze_episodes_by_date",
+        side_effect=tvmaze_episodes_by_date,
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_args() -> None:
     """Clears argv before and after running test."""
     del sys.argv[:]
     sys.argv.append("mnamer")
 
 
 @pytest.fixture
-def e2e_run(capsys, request):
+def e2e_run(
+    capsys: pytest.CaptureFixture[str], request: pytest.FixtureRequest
+) -> Callable[..., E2EResult]:
     """Runs main with provided arguments and returns stdout."""
 
-    def fn(*args):
+    def fn(*args: str) -> E2EResult:
         Target.reset_providers()
         out = ""
         code = 0
@@ -48,7 +367,7 @@ def e2e_run(capsys, request):
             out += str(e)
             code = 2
         except SystemExit as e:
-            code = e.code
+            code = e.code if isinstance(e.code, int) else 1
         out += strip_format(capsys.readouterr().out.strip())
         out += strip_format(capsys.readouterr().err.strip())
         with open(E2E_LOG, "a+") as fp:

--- a/tests/e2e/test_moving.py
+++ b/tests/e2e/test_moving.py
@@ -106,9 +106,6 @@ def test_mask(e2e_run, setup_test_files):
 
 
 @pytest.mark.usefixtures("setup_test_dir")
-@pytest.mark.skip(
-    reason="Multi-part integration broken with latest guessit 3.8, but needed for python 3.13 compatibility"
-)
 def test_multi_part_episode(e2e_run, setup_test_files):
     setup_test_files("lost s01e01-02.mp4")
     result = e2e_run("--batch", ".")
@@ -195,7 +192,6 @@ def test_format_id(e2e_run, setup_test_files):
 
 
 @pytest.mark.tvdb
-@pytest.mark.xfail(strict=False)
 @pytest.mark.usefixtures("setup_test_dir")
 def test_format_id__tvdb(e2e_run, setup_test_files):
     setup_test_files("archer.2009.s10e07.webrip.x264-lucidtv.mp4")
@@ -210,7 +206,6 @@ def test_format_id__tvdb(e2e_run, setup_test_files):
 
 
 @pytest.mark.tvmaze
-@pytest.mark.xfail(strict=False)
 @pytest.mark.usefixtures("setup_test_dir")
 def test_format_season0(e2e_run, setup_test_files):
     setup_test_files("south.park.s00e01.mp4")

--- a/tests/local/test_providers.py
+++ b/tests/local/test_providers.py
@@ -1,0 +1,415 @@
+import datetime as dt
+
+import pytest
+
+from mnamer.exceptions import MnamerNotFoundException
+from mnamer.language import Language
+from mnamer.metadata import MetadataEpisode, MetadataMovie
+from mnamer.providers import Omdb, Provider, Tmdb, Tvdb, TvMaze
+from mnamer.setting_store import SettingStore
+from mnamer.types import ProviderType
+
+pytestmark = pytest.mark.local
+
+
+OMDB_TITLE = {
+    "title": "Example Movie",
+    "year": "2020",
+    "released": "15 May 2020",
+    "plot": "Example plot.",
+    "imdb_id": "tt1234567",
+}
+
+TMDB_MOVIE = {
+    "id": 42,
+    "title": "Example Movie",
+    "release_date": "2020-05-15",
+    "overview": "Example overview.",
+    "imdb_id": "tt1234567",
+}
+
+TVDB_SERIES = {"data": {"id": 100, "series_name": "Example Series"}}
+
+TVDB_EPISODE = {
+    "first_aired": "2020-01-02",
+    "aired_episode_number": 2,
+    "aired_season": 1,
+    "overview": "Example overview.",
+    "episode_name": "Episode Two",
+}
+
+TVMAZE_SHOW = {
+    "id": 200,
+    "name": "Example Series",
+    "externals": {"thetvdb": 100, "imdb": "tt7654321"},
+}
+
+TVMAZE_EPISODE = {
+    "airdate": "2020-01-02",
+    "number": 2,
+    "season": 1,
+    "name": "Episode Two",
+    "summary": "Example summary.",
+}
+
+
+def test_provider_factory__returns_configured_provider_types():
+    settings = SettingStore()
+
+    assert isinstance(Provider.provider_factory(ProviderType.OMDB, settings), Omdb)
+    assert isinstance(Provider.provider_factory(ProviderType.TMDB, settings), Tmdb)
+    assert isinstance(Provider.provider_factory(ProviderType.TVDB, settings), Tvdb)
+    assert isinstance(Provider.provider_factory(ProviderType.TVMAZE, settings), TvMaze)
+
+
+def test_provider_from_settings__uses_api_key_and_cache_flag():
+    settings = SettingStore(api_key_omdb="configured-key", no_cache=True)
+
+    provider = Omdb.from_settings(settings)
+
+    assert provider.api_key == "configured-key"
+    assert provider.cache is False
+
+
+def test_tvdb_from_settings__logs_in_when_cache_is_disabled(mocker):
+    mock_login = mocker.patch("mnamer.providers.tvdb_login", return_value="token")
+    settings = SettingStore(api_key_tvdb="configured-key", no_cache=True)
+
+    provider = Tvdb.from_settings(settings)
+
+    assert provider.cache is False
+    assert provider.token == "token"
+    mock_login.assert_called_once_with("configured-key")
+
+
+def test_omdb_search__id_lookup(mocker):
+    mock_title = mocker.patch("mnamer.providers.omdb_title", return_value=OMDB_TITLE)
+
+    result = next(Omdb("key").search(MetadataMovie(id_imdb="tt1234567")))
+
+    assert result.name == "Example Movie"
+    assert result.year == 2020
+    assert result.id_imdb == "tt1234567"
+    assert result.synopsis == "Example plot."
+    mock_title.assert_called_once_with("key", "tt1234567", cache=True)
+
+
+def test_omdb_search__fallback_year_and_na_synopsis(mocker):
+    mocker.patch(
+        "mnamer.providers.omdb_title",
+        return_value={
+            "title": "Fallback Movie",
+            "year": "1999",
+            "plot": "N/A",
+            "imdb_id": "tt7654321",
+        },
+    )
+
+    result = next(Omdb("key").search(MetadataMovie(id_imdb="tt7654321")))
+
+    assert result.year == 1999
+    assert result.synopsis is None
+
+
+def test_omdb_search__title_filters_year_and_stops_on_not_found(mocker):
+    mock_search = mocker.patch(
+        "mnamer.providers.omdb_search",
+        side_effect=[
+            {
+                "search": [
+                    {"imdb_id": "tt0000001", "title": "Old Hit", "year": "2010"},
+                    {
+                        "imdb_id": "tt1234567",
+                        "title": "Example Movie",
+                        "year": "2020",
+                    },
+                ],
+                "total_results": "2",
+            },
+            MnamerNotFoundException,
+        ],
+    )
+    mock_title = mocker.patch("mnamer.providers.omdb_title", return_value=OMDB_TITLE)
+
+    results = list(Omdb("key").search(MetadataMovie(name="Example", year="2020")))
+
+    assert [result.id_imdb for result in results] == ["tt1234567"]
+    assert mock_search.call_count == 2
+    mock_title.assert_called_once_with("key", "tt1234567", cache=True)
+
+
+def test_omdb_search__missing_query():
+    with pytest.raises(MnamerNotFoundException):
+        next(Omdb("key").search(MetadataMovie()))
+
+
+def test_omdb_search__no_hits(mocker):
+    mocker.patch("mnamer.providers.omdb_search", side_effect=MnamerNotFoundException)
+
+    with pytest.raises(MnamerNotFoundException):
+        next(Omdb("key").search(MetadataMovie(name="Missing")))
+
+
+def test_tmdb_search__id_lookup_forwards_language_and_cache(mocker):
+    mock_movies = mocker.patch("mnamer.providers.tmdb_movies", return_value=TMDB_MOVIE)
+    language = Language.parse("en")
+
+    result = next(
+        Tmdb("key", cache=False).search(MetadataMovie(id_tmdb="42", language=language))
+    )
+
+    assert result.name == "Example Movie"
+    assert result.year == 2020
+    assert result.id_tmdb == "42"
+    assert result.id_imdb == "tt1234567"
+    mock_movies.assert_called_once_with("key", "42", language, False)
+
+
+def test_tmdb_search__name_skips_malformed_and_undated_results(mocker):
+    mocker.patch(
+        "mnamer.providers.tmdb_search_movies",
+        return_value={
+            "results": [
+                {"id": 1, "title": "Undated Movie", "release_date": ""},
+                {"id": 2, "release_date": "2020-01-01"},
+                TMDB_MOVIE,
+            ],
+            "total_pages": 1,
+            "total_results": 3,
+        },
+    )
+
+    results = list(Tmdb("key").search(MetadataMovie(name="Example")))
+
+    assert [result.id_tmdb for result in results] == ["42"]
+
+
+def test_tmdb_search__name_stops_at_page_limit(mocker):
+    mock_search = mocker.patch(
+        "mnamer.providers.tmdb_search_movies",
+        return_value={"results": [], "total_pages": 7, "total_results": 7},
+    )
+
+    with pytest.raises(MnamerNotFoundException):
+        next(Tmdb("key").search(MetadataMovie(name="Missing")))
+
+    assert mock_search.call_count == 5
+
+
+def test_tmdb_search__missing_query():
+    with pytest.raises(MnamerNotFoundException):
+        next(Tmdb("key").search(MetadataMovie()))
+
+
+def test_tmdb_search__no_hits(mocker):
+    mocker.patch(
+        "mnamer.providers.tmdb_search_movies",
+        side_effect=MnamerNotFoundException,
+    )
+
+    with pytest.raises(MnamerNotFoundException):
+        next(Tmdb("key").search(MetadataMovie(name="Missing")))
+
+
+def test_tvdb_search__lazy_login_and_id_search(mocker):
+    mock_login = mocker.patch("mnamer.providers.tvdb_login", return_value="token")
+    mock_series = mocker.patch(
+        "mnamer.providers.tvdb_series_id", return_value=TVDB_SERIES
+    )
+    mock_episodes = mocker.patch(
+        "mnamer.providers.tvdb_series_id_episodes_query",
+        return_value={"data": [TVDB_EPISODE], "links": {"last": 1}},
+    )
+    provider = Tvdb("key")
+
+    result = next(provider.search(MetadataEpisode(id_tvdb="100", season=1, episode=2)))
+
+    assert result.series == "Example Series"
+    assert result.title == "Episode Two"
+    assert result.id_tvdb == "100"
+    mock_login.assert_called_once_with("key")
+    mock_series.assert_called_once_with("token", "100", language=None, cache=True)
+    mock_episodes.assert_called_once_with(
+        "token",
+        "100",
+        2,
+        1,
+        language=None,
+        page=1,
+        cache=True,
+    )
+
+
+def test_tvdb_search__paginates_and_skips_bad_episode_rows(mocker):
+    mocker.patch("mnamer.providers.tvdb_login", return_value="token")
+    mocker.patch("mnamer.providers.tvdb_series_id", return_value=TVDB_SERIES)
+    mock_episodes = mocker.patch(
+        "mnamer.providers.tvdb_series_id_episodes_query",
+        side_effect=[
+            {
+                "data": [{"first_aired": "2020-01-01"}],
+                "links": {"last": 2},
+            },
+            {"data": [TVDB_EPISODE], "links": {"last": 2}},
+        ],
+    )
+
+    results = list(Tvdb("key").search(MetadataEpisode(id_tvdb="100")))
+
+    assert [result.title for result in results] == ["Episode Two"]
+    assert mock_episodes.call_count == 2
+
+
+def test_tvdb_search__series_tries_candidate_ids(mocker):
+    provider = Tvdb("key")
+    provider.token = "token"
+    mocker.patch(
+        "mnamer.providers.tvdb_search_series",
+        return_value={"data": [{"id": 1}, {"id": 100}]},
+    )
+    mock_search_id = mocker.patch.object(
+        provider,
+        "_search_id",
+        side_effect=[
+            MnamerNotFoundException,
+            [MetadataEpisode(id_tvdb="100", series="Example Series", season=1)],
+        ],
+    )
+
+    results = list(provider.search(MetadataEpisode(series="Example Series")))
+
+    assert [result.id_tvdb for result in results] == ["100"]
+    assert mock_search_id.call_count == 2
+
+
+def test_tvdb_search__date_filters_id_results(mocker):
+    provider = Tvdb("key")
+    provider.token = "token"
+    mocker.patch.object(
+        provider,
+        "_search_id",
+        return_value=[
+            MetadataEpisode(id_tvdb="100", date=dt.date(2020, 1, 1)),
+            MetadataEpisode(id_tvdb="100", date=dt.date(2020, 1, 2)),
+        ],
+    )
+
+    results = list(
+        provider.search(MetadataEpisode(id_tvdb="100", date=dt.date(2020, 1, 2)))
+    )
+
+    assert [result.date for result in results] == [dt.date(2020, 1, 2)]
+
+
+def test_tvdb_search__missing_query():
+    provider = Tvdb("key")
+    provider.token = "token"
+
+    with pytest.raises(MnamerNotFoundException):
+        next(provider.search(MetadataEpisode()))
+
+
+def test_tvmaze_search__tvmaze_id_season_episode(mocker):
+    mocker.patch("mnamer.providers.tvmaze_show", return_value=TVMAZE_SHOW)
+    mocker.patch(
+        "mnamer.providers.tvmaze_episode_by_number",
+        return_value=TVMAZE_EPISODE,
+    )
+
+    result = next(
+        TvMaze().search(MetadataEpisode(id_tvmaze="200", season=1, episode=2))
+    )
+
+    assert result.series == "Example Series"
+    assert result.title == "Episode Two"
+    assert result.id_tvmaze == "200"
+    assert result.id_tvdb == "100"
+
+
+def test_tvmaze_search__tvdb_id_date_lookup(mocker):
+    mocker.patch("mnamer.providers.tvmaze_show_lookup", return_value=TVMAZE_SHOW)
+    mocker.patch(
+        "mnamer.providers.tvmaze_episodes_by_date",
+        return_value=[TVMAZE_EPISODE],
+    )
+
+    result = next(
+        TvMaze().search(MetadataEpisode(id_tvdb="100", date=dt.date(2020, 1, 2)))
+    )
+
+    assert result.id_tvmaze == "200"
+    assert result.id_tvdb == "100"
+    assert result.date == dt.date(2020, 1, 2)
+
+
+def test_tvmaze_search__id_filters_episode_list(mocker):
+    mocker.patch("mnamer.providers.tvmaze_show", return_value=TVMAZE_SHOW)
+    mocker.patch(
+        "mnamer.providers.tvmaze_show_episodes_list",
+        return_value=[
+            {**TVMAZE_EPISODE, "number": 1, "name": "Episode One"},
+            TVMAZE_EPISODE,
+        ],
+    )
+
+    results = list(TvMaze().search(MetadataEpisode(id_tvmaze="200", episode=2)))
+
+    assert [result.title for result in results] == ["Episode Two"]
+
+
+def test_tvmaze_search__series_season_episode_tries_first_three(mocker):
+    shows = [
+        {"show": {**TVMAZE_SHOW, "id": 201}},
+        {"show": TVMAZE_SHOW},
+        {"show": {**TVMAZE_SHOW, "id": 202}},
+        {"show": {**TVMAZE_SHOW, "id": 203}},
+    ]
+    mocker.patch("mnamer.providers.tvmaze_show_search", return_value=shows)
+    mock_episode = mocker.patch(
+        "mnamer.providers.tvmaze_episode_by_number",
+        side_effect=[
+            MnamerNotFoundException,
+            TVMAZE_EPISODE,
+            MnamerNotFoundException,
+        ],
+    )
+
+    results = list(
+        TvMaze().search(MetadataEpisode(series="Example Series", season=1, episode=2))
+    )
+
+    assert [result.id_tvmaze for result in results] == ["200"]
+    assert mock_episode.call_count == 3
+
+
+def test_tvmaze_search__series_filters_episode_list(mocker):
+    mocker.patch(
+        "mnamer.providers.tvmaze_show_search",
+        return_value=[{"show": TVMAZE_SHOW}],
+    )
+    mocker.patch(
+        "mnamer.providers.tvmaze_show_episodes_list",
+        return_value=[
+            {**TVMAZE_EPISODE, "season": 2, "name": "Wrong Season"},
+            TVMAZE_EPISODE,
+        ],
+    )
+
+    results = list(TvMaze().search(MetadataEpisode(series="Example Series", season=1)))
+
+    assert [result.title for result in results] == ["Episode Two"]
+
+
+def test_tvmaze_search__missing_query():
+    with pytest.raises(MnamerNotFoundException):
+        next(TvMaze().search(MetadataEpisode()))
+
+
+def test_tvmaze_search__no_hits(mocker):
+    mocker.patch(
+        "mnamer.providers.tvmaze_show_search",
+        side_effect=MnamerNotFoundException,
+    )
+
+    with pytest.raises(MnamerNotFoundException):
+        next(TvMaze().search(MetadataEpisode(series="Missing")))

--- a/tests/local/test_setting_spec.py
+++ b/tests/local/test_setting_spec.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from mnamer.setting_spec import SettingSpec
@@ -22,7 +24,7 @@ def test_setting_spec__serialize__default():
 
 
 def test_setting_spec__serialize__override():
-    spec = {
+    spec: dict[str, Any] = {
         "action": "count",
         "choices": ["a", "b", "c"],
         "dest": "foo",
@@ -37,7 +39,7 @@ def test_setting_spec__serialize__override():
 
 
 def test_setting_spec__registration():
-    spec = {
+    spec: dict[str, Any] = {
         "dest": "foo",
         "flags": ["-f", "--f"],
         "group": SettingType.DIRECTIVE,
@@ -50,7 +52,7 @@ def test_setting_spec__registration():
 
 
 def test_setting_spec__name__flags():
-    spec = {
+    spec: dict[str, Any] = {
         "dest": "foo",
         "flags": ["-f", "--foo"],
         "group": SettingType.DIRECTIVE,
@@ -61,7 +63,7 @@ def test_setting_spec__name__flags():
 
 
 def test_setting_spec__name__no_flags():
-    spec = {
+    spec: dict[str, Any] = {
         "dest": "foo",
         "group": SettingType.CONFIGURATION,
         "help": "foos your bars",

--- a/tests/local/test_utils.py
+++ b/tests/local/test_utils.py
@@ -579,7 +579,8 @@ def test_request_json__html_data(mock_request):
 @patch("mnamer.utils.requests_cache.CachedSession.request")
 def test_request_json__get_headers(mock_request):
     mock_request.side_effect = Session().request
-    request_json(url="http://google.com", headers={"apple": "pie", "orange": None})
+    headers: dict[str, object] = {"apple": "pie", "orange": None}
+    request_json(url="http://google.com", headers=headers)
     _, kwargs = mock_request.call_args
     assert kwargs["method"] == "GET"
     assert len(kwargs["headers"]) == 2
@@ -626,7 +627,7 @@ def test_request_json__post_parameters(mock_request):
 @patch("mnamer.utils.requests_cache.CachedSession.request")
 def test_request_json__post_headers(mock_request):
     mock_request.side_effect = Session().request
-    data = {"apple": "pie", "orange": None}
+    data: dict[str, object] = {"apple": "pie", "orange": None}
     request_json(url="http://google.com", body=data, headers=data)
     _, kwargs = mock_request.call_args
     assert kwargs["method"] == "POST"

--- a/tests/network/test_endpoints__tmdb.py
+++ b/tests/network/test_endpoints__tmdb.py
@@ -123,7 +123,6 @@ def test_tmdb_movies__not_found():
         tmdb_movies(Tmdb.api_key, "1" * 10)
 
 
-@pytest.mark.xfail(strict=False)
 def test_tmdb_movies__language():
     result = tmdb_movies(Tmdb.api_key, GOONIES_TMDB_ID, RUSSIAN_LANG)
     assert result.get("title") == "Балбесы"

--- a/tests/network/test_endpoints__tvdb.py
+++ b/tests/network/test_endpoints__tvdb.py
@@ -61,16 +61,16 @@ EXPECTED_TOP_LEVEL_SHOW_KEYS = {
 LOST_TVDB_ID_EPISODE = "127131"
 LOST_TVDB_ID_SERIES = "73739"
 THE_WITCHER_ID_SERIES = "362696"
+_tvdb_token: str | None = None
 
 
 @pytest.fixture(scope="session")
-def tvdb_token():
+def tvdb_token() -> str:
     """Calls mnamer.endpoints.tvdb_login then returns cached token."""
-    if not hasattr(tvdb_token, "token"):
-        from mnamer.endpoints import tvdb_login
-
-        tvdb_token.token = tvdb_login(Tvdb.api_key)
-    return tvdb_token.token
+    global _tvdb_token
+    if _tvdb_token is None:
+        _tvdb_token = tvdb_login(Tvdb.api_key)
+    return _tvdb_token
 
 
 def test_tvdb_login__login_success():
@@ -92,7 +92,6 @@ def test_tvdb_refresh_token__refresh_fail():
         tvdb_refresh_token(JUNK_TEXT)
 
 
-@pytest.mark.xfail(strict=False)
 def test_tvdb_episodes_id__invalid_token():
     with pytest.raises(MnamerException):
         tvdb_episodes_id(JUNK_TEXT, LOST_TVDB_ID_EPISODE, cache=False)
@@ -138,7 +137,6 @@ def test_tvdb_episodes_id__language__invalid(tvdb_token):
         tvdb_episodes_id(tvdb_token, LOST_TVDB_ID_EPISODE, invalid_language)
 
 
-@pytest.mark.xfail(strict=False)
 def test_tvdb_series_id__invalid_token():
     with pytest.raises(MnamerException):
         tvdb_series_id(JUNK_TEXT, LOST_TVDB_ID_SERIES, cache=False)
@@ -208,7 +206,6 @@ def test_tvdb_series_id__language(tvdb_token):
     assert result["data"]["series_name"] == "Ведьмак"
 
 
-@pytest.mark.xfail(strict=False)
 def test_tvdb_series_id_episodes__invalid_token():
     with pytest.raises(MnamerException):
         tvdb_series_id_episodes(JUNK_TEXT, LOST_TVDB_ID_SERIES, cache=False)
@@ -250,7 +247,6 @@ def test_tvdb_series_id_episodes__language(tvdb_token):
     assert result["data"][0]["episode_name"] == "Начало конца"
 
 
-@pytest.mark.xfail(strict=False)
 def test_tvdb_series_id_episodes_query__invalid_token():
     with pytest.raises(MnamerException):
         tvdb_series_id_episodes_query(JUNK_TEXT, LOST_TVDB_ID_SERIES, cache=False)

--- a/tests/network/test_endpoints__tvmaze.py
+++ b/tests/network/test_endpoints__tvmaze.py
@@ -61,7 +61,7 @@ EXPECTED_EPISODE_KEYS = [
 
 
 def test_tvmaze_show():
-    result = tvmaze_show(id_tvmaze=META["id_tvmaze"])
+    result = tvmaze_show(id_tvmaze=str(META["id_tvmaze"]))
     assert result
     for expected_show_key in EXPECTED_SHOW_KEYS:
         assert expected_show_key in result
@@ -93,7 +93,7 @@ def test_tvmaze_show__embed_episodes():
         "web_channel",
         "weight",
     ]
-    result = tvmaze_show(id_tvmaze=META["id_tvmaze"], embed_episodes=True)
+    result = tvmaze_show(id_tvmaze=str(META["id_tvmaze"]), embed_episodes=True)
     assert result
     for expected_show_key in expected_show_keys:
         assert expected_show_key in result
@@ -102,7 +102,7 @@ def test_tvmaze_show__embed_episodes():
 
 
 def test_tvmaze_show_search__success():
-    results = tvmaze_show_search(META["series"])
+    results = tvmaze_show_search(str(META["series"]))
     expected_top_level_keys = {"score", "show"}
     assert results
     result = results[0]
@@ -119,7 +119,7 @@ def test_tvmaze_show_search__no_hits():
 
 
 def test_tvmaze_show_single_search__success():
-    result = tvmaze_show_single_search(META["series"])
+    result = tvmaze_show_single_search(str(META["series"]))
     assert result
     for expected_show_key in EXPECTED_SHOW_KEYS:
         assert expected_show_key in result
@@ -133,7 +133,7 @@ def test_tvmaze_show_single_search__no_hits():
 
 
 def test_tvmaze_show_lookup__idmb__success():
-    result = tvmaze_show_lookup(id_imdb=META["id_imdb"])
+    result = tvmaze_show_lookup(id_imdb=str(META["id_imdb"]))
     assert result
     for expected_show_key in EXPECTED_SHOW_KEYS:
         assert expected_show_key in result
@@ -147,7 +147,7 @@ def test_tvmaze_show_lookup__idmb__no_hits():
 
 
 def test_tvmaze_show_lookup__tvdb__success():
-    result = tvmaze_show_lookup(id_tvdb=META["id_tvdb"])
+    result = tvmaze_show_lookup(id_tvdb=str(META["id_tvdb"]))
     assert result
     for expected_show_key in EXPECTED_SHOW_KEYS:
         assert expected_show_key in result
@@ -167,11 +167,11 @@ def test_tvmaze_show_lookup__missing_id():
 
 def test_tvmaze_show_lookup__both_ids():
     with pytest.raises(MnamerException):
-        tvmaze_show_lookup(id_imdb=META["id_imdb"], id_tvdb=META["id_tvdb"])
+        tvmaze_show_lookup(id_imdb=str(META["id_imdb"]), id_tvdb=str(META["id_tvdb"]))
 
 
 def test_tvmaze_show_episodes_list__success():
-    results = tvmaze_show_episodes_list(META["id_tvmaze"])
+    results = tvmaze_show_episodes_list(str(META["id_tvmaze"]))
     assert results
     result = results[0]
     for expected_episode_key in EXPECTED_EPISODE_KEYS:
@@ -197,11 +197,11 @@ def test_tvmaze_episodes_by_date__no_hits__bad_id():
 
 def test_tvmaze_episodes_by_date__no_hits__bad_date():
     with pytest.raises(MnamerNotFoundException):
-        tvmaze_episodes_by_date(META["id_tvmaze"], TEST_DATE)
+        tvmaze_episodes_by_date(str(META["id_tvmaze"]), TEST_DATE)
 
 
 def test_tvmaze_episode_by_number__success():
-    target_id = EPISODE_META["The Walking Dead"]["id_tvmaze"]
+    target_id = str(EPISODE_META["The Walking Dead"]["id_tvmaze"])
     result = tvmaze_episode_by_number(target_id, 3, 3)
     assert result
     assert result["id"] == 4116

--- a/tests/network/test_providers__omdb.py
+++ b/tests/network/test_providers__omdb.py
@@ -3,7 +3,7 @@ import pytest
 from mnamer.exceptions import MnamerNotFoundException
 from mnamer.metadata import MetadataMovie
 from mnamer.providers import Omdb
-from tests import JUNK_TEXT, MOVIE_META
+from tests import JUNK_TEXT, MOVIE_META, MovieMeta
 
 pytestmark = [
     pytest.mark.network,
@@ -18,7 +18,7 @@ def provider():
 
 
 @pytest.mark.parametrize("meta", MOVIE_META.values(), ids=list(MOVIE_META))
-def test_search__id(meta: dict[str, str], provider: Omdb):
+def test_search__id(meta: MovieMeta, provider: Omdb):
     query = MetadataMovie(id_imdb=meta["id_imdb"])
     results = list(provider.search(query))
     assert len(results) == 1

--- a/tests/network/test_providers__tmdb.py
+++ b/tests/network/test_providers__tmdb.py
@@ -3,7 +3,7 @@ import pytest
 from mnamer.exceptions import MnamerNotFoundException
 from mnamer.metadata import MetadataMovie
 from mnamer.providers import Tmdb
-from tests import JUNK_TEXT, MOVIE_META
+from tests import JUNK_TEXT, MOVIE_META, MovieMeta
 
 pytestmark = [
     pytest.mark.network,
@@ -18,8 +18,8 @@ def provider():
 
 
 @pytest.mark.parametrize("meta", MOVIE_META.values(), ids=list(MOVIE_META))
-def test_search_id(meta: dict, provider: Tmdb):
-    query = MetadataMovie(id_tmdb=meta["id_tmdb"])
+def test_search_id(meta: MovieMeta, provider: Tmdb):
+    query = MetadataMovie(id_tmdb=str(meta["id_tmdb"]))
     results = list(provider.search(query))
     assert len(results) == 1
     result = results[0]
@@ -33,7 +33,7 @@ def test_search_id__no_hits(provider: Tmdb):
 
 
 @pytest.mark.parametrize("meta", MOVIE_META.values(), ids=list(MOVIE_META))
-def test_search__name(meta: dict, provider: Tmdb):
+def test_search__name(meta: MovieMeta, provider: Tmdb):
     query = MetadataMovie(name=meta["name"])
     assert any(
         result.id_tmdb == str(meta["id_tmdb"]) for result in provider.search(query)

--- a/tests/network/test_providers__tvdb.py
+++ b/tests/network/test_providers__tvdb.py
@@ -5,7 +5,7 @@ import pytest
 from mnamer.exceptions import MnamerNotFoundException
 from mnamer.metadata import MetadataEpisode
 from mnamer.providers import Tvdb
-from tests import EPISODE_META, JUNK_TEXT
+from tests import EPISODE_META, JUNK_TEXT, EpisodeMeta
 
 pytestmark = [
     pytest.mark.network,
@@ -20,8 +20,8 @@ def provider():
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
-def test_search_id(meta: dict, provider: Tvdb):
-    query = MetadataEpisode(id_tvdb=meta["id_tvdb"])
+def test_search_id(meta: EpisodeMeta, provider: Tvdb):
+    query = MetadataEpisode(id_tvdb=str(meta["id_tvdb"]))
     results = list(provider.search(query))
     assert results
     for result in results:
@@ -35,7 +35,7 @@ def test_search_id__no_hits(provider: Tvdb):
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
-def test_search__series(meta: dict, provider: Tvdb):
+def test_search__series(meta: EpisodeMeta, provider: Tvdb):
     query = MetadataEpisode(series=meta["series"])
     assert any(
         result.id_tvdb == str(meta["id_tvdb"]) for result in provider.search(query)
@@ -43,24 +43,26 @@ def test_search__series(meta: dict, provider: Tvdb):
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
-def test_search__id_tvdb_season(meta: dict, provider: Tvdb):
-    query = MetadataEpisode(season=1, id_tvdb=meta["id_tvdb"])
+def test_search__id_tvdb_season(meta: EpisodeMeta, provider: Tvdb):
+    query = MetadataEpisode(season=1, id_tvdb=str(meta["id_tvdb"]))
     results = provider.search(query)
     all_season_1 = all(entry.season == 1 for entry in results)
     assert all_season_1 is True
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
-def test_search__id_tvdb_episode(meta: dict, provider: Tvdb):
-    query = MetadataEpisode(episode=2, id_tvdb=meta["id_tvdb"])
+def test_search__id_tvdb_episode(meta: EpisodeMeta, provider: Tvdb):
+    query = MetadataEpisode(episode=2, id_tvdb=str(meta["id_tvdb"]))
     results = provider.search(query)
     all_episode_2 = all(entry.episode == 2 for entry in results)
     assert all_episode_2 is True
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
-def test_tvdb_provider__search__id_tvdb_season_episode(meta: dict, provider: Tvdb):
-    query = MetadataEpisode(season=1, episode=3, id_tvdb=meta["id_tvdb"])
+def test_tvdb_provider__search__id_tvdb_season_episode(
+    meta: EpisodeMeta, provider: Tvdb
+):
+    query = MetadataEpisode(season=1, episode=3, id_tvdb=str(meta["id_tvdb"]))
     results = list(provider.search(query))
     assert len(results) == 1
     assert results[0].season == 1
@@ -68,7 +70,7 @@ def test_tvdb_provider__search__id_tvdb_season_episode(meta: dict, provider: Tvd
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
-def test_tvdb_provider__search__series(meta: dict, provider: Tvdb):
+def test_tvdb_provider__search__series(meta: EpisodeMeta, provider: Tvdb):
     query = MetadataEpisode(series=meta["series"])
     found = False
     results = provider.search(query)
@@ -86,7 +88,7 @@ def test_tvdb_provider__search__series_deep(provider: Tvdb):
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
-def test_tvdb_provider__search__title_season(meta: dict, provider: Tvdb):
+def test_tvdb_provider__search__title_season(meta: EpisodeMeta, provider: Tvdb):
     query = MetadataEpisode(series=meta["series"], season=1)
     results = provider.search(query)
     all_season_1 = all(entry.season == 1 for entry in results)
@@ -94,7 +96,7 @@ def test_tvdb_provider__search__title_season(meta: dict, provider: Tvdb):
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
-def test_tvdb_provider__search__title_season_episode(meta: dict, provider: Tvdb):
+def test_tvdb_provider__search__title_season_episode(meta: EpisodeMeta, provider: Tvdb):
     query = MetadataEpisode(series=meta["series"], season=1, episode=3)
     results = list(provider.search(query))
     assert results[0].season == 1

--- a/tests/network/test_providers__tvmaze.py
+++ b/tests/network/test_providers__tvmaze.py
@@ -3,7 +3,7 @@ import pytest
 from mnamer.exceptions import MnamerNotFoundException
 from mnamer.metadata import MetadataEpisode
 from mnamer.providers import TvMaze
-from tests import EPISODE_META, JUNK_TEXT, TEST_DATE
+from tests import EPISODE_META, JUNK_TEXT, TEST_DATE, EpisodeMeta
 
 pytestmark = [
     pytest.mark.network,
@@ -18,9 +18,11 @@ def provider():
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
-def test_search_id_tvmaze_and_season_and_episode(meta: dict, provider: TvMaze):
+def test_search_id_tvmaze_and_season_and_episode(meta: EpisodeMeta, provider: TvMaze):
     query = MetadataEpisode(
-        id_tvmaze=meta["id_tvmaze"], season=meta["season"], episode=meta["episode"]
+        id_tvmaze=str(meta["id_tvmaze"]),
+        season=meta["season"],
+        episode=meta["episode"],
     )
     results = list(provider.search(query))
     assert results
@@ -35,8 +37,8 @@ def test_search_id_tvmaze_and_season_and_episode__no_hits(provider: TvMaze):
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
-def test_search_id_tvmaze_and_date(meta: dict, provider: TvMaze):
-    query = MetadataEpisode(id_tvmaze=meta["id_tvmaze"], date=meta["date"])
+def test_search_id_tvmaze_and_date(meta: EpisodeMeta, provider: TvMaze):
+    query = MetadataEpisode(id_tvmaze=str(meta["id_tvmaze"]), date=meta["date"])
     results = list(provider.search(query))
     assert results
     for result in results:
@@ -65,8 +67,8 @@ def test_search_id_tvdb_and_date__no_hits(provider: TvMaze):
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
-def test_search_id_tvmaze_and_season(meta: dict, provider: TvMaze):
-    query = MetadataEpisode(id_tvmaze=meta["id_tvmaze"], season=meta["season"])
+def test_search_id_tvmaze_and_season(meta: EpisodeMeta, provider: TvMaze):
+    query = MetadataEpisode(id_tvmaze=str(meta["id_tvmaze"]), season=meta["season"])
     results = list(provider.search(query))
     assert results
     assert any(result.title == meta["title"] for result in results)
@@ -74,8 +76,8 @@ def test_search_id_tvmaze_and_season(meta: dict, provider: TvMaze):
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
-def test_search_id_tvmaze_and_episode(meta: dict, provider: TvMaze):
-    query = MetadataEpisode(id_tvmaze=meta["id_tvmaze"], episode=meta["episode"])
+def test_search_id_tvmaze_and_episode(meta: EpisodeMeta, provider: TvMaze):
+    query = MetadataEpisode(id_tvmaze=str(meta["id_tvmaze"]), episode=meta["episode"])
     results = list(provider.search(query))
     assert results
     assert any(result.title == meta["title"] for result in results)
@@ -83,8 +85,8 @@ def test_search_id_tvmaze_and_episode(meta: dict, provider: TvMaze):
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
-def test_search_id_tvmaze(meta: dict, provider: TvMaze):
-    query = MetadataEpisode(id_tvmaze=meta["id_tvmaze"])
+def test_search_id_tvmaze(meta: EpisodeMeta, provider: TvMaze):
+    query = MetadataEpisode(id_tvmaze=str(meta["id_tvmaze"]))
     results = list(provider.search(query))
     assert results
     assert any(result.title == meta["title"] for result in results)
@@ -97,8 +99,8 @@ def test_search_id_tvmaze__no_hits(provider: TvMaze):
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
-def test_search_id_tvdb(meta: dict, provider: TvMaze):
-    query = MetadataEpisode(id_tvdb=meta["id_tvdb"])
+def test_search_id_tvdb(meta: EpisodeMeta, provider: TvMaze):
+    query = MetadataEpisode(id_tvdb=str(meta["id_tvdb"]))
     results = list(provider.search(query))
     assert results
     assert any(result.title == meta["title"] for result in results)
@@ -111,7 +113,7 @@ def test_search_id_tvdb__no_hits(provider: TvMaze):
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
-def test_search_series_and_season_and_episode(meta: dict, provider: TvMaze):
+def test_search_series_and_season_and_episode(meta: EpisodeMeta, provider: TvMaze):
     query = MetadataEpisode(
         series=meta["series"], season=meta["season"], episode=meta["episode"]
     )
@@ -127,7 +129,7 @@ def test_search_series_and_season_and_episode__no_hits(provider: TvMaze):
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
-def test_search_series_and_season(meta: dict, provider: TvMaze):
+def test_search_series_and_season(meta: EpisodeMeta, provider: TvMaze):
     query = MetadataEpisode(series=meta["series"], season=meta["season"])
     results = list(provider.search(query))
     assert results
@@ -141,7 +143,7 @@ def test_search_series_and_season__no_hits(provider):
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
-def test_search_series_and_episode(meta: dict, provider: TvMaze):
+def test_search_series_and_episode(meta: EpisodeMeta, provider: TvMaze):
     query = MetadataEpisode(series=meta["series"], episode=meta["episode"])
     results = list(provider.search(query))
     assert results
@@ -155,7 +157,7 @@ def test_search_series_and_episode__no_hits(provider: TvMaze):
 
 
 @pytest.mark.parametrize("meta", EPISODE_META.values(), ids=list(EPISODE_META))
-def test_search_series(meta: dict, provider: TvMaze):
+def test_search_series(meta: EpisodeMeta, provider: TvMaze):
     query = MetadataEpisode(series=meta["series"])
     results = list(provider.search(query))
     assert results

--- a/uv.lock
+++ b/uv.lock
@@ -76,11 +76,11 @@ wheels = [
 
 [[package]]
 name = "attrs"
-version = "25.3.0"
+version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b", size = 812032, upload-time = "2025-03-13T11:10:22.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3", size = 63815, upload-time = "2025-03-13T11:10:21.14Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -108,15 +108,15 @@ wheels = [
 
 [[package]]
 name = "cattrs"
-version = "25.1.1"
+version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/2b/561d78f488dcc303da4639e02021311728fb7fda8006dd2835550cddd9ed/cattrs-25.1.1.tar.gz", hash = "sha256:c914b734e0f2d59e5b720d145ee010f1fd9a13ee93900922a2f3f9d593b8382c", size = 435016, upload-time = "2025-06-04T20:27:15.44Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672, upload-time = "2026-02-18T22:15:19.406Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/b0/215274ef0d835bbc1056392a367646648b6084e39d489099959aefcca2af/cattrs-25.1.1-py3-none-any.whl", hash = "sha256:1b40b2d3402af7be79a7e7e097a9b4cd16d4c06e6d526644b0b26a063a1cc064", size = 69386, upload-time = "2025-06-04T20:27:13.969Z" },
+    { url = "https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl", hash = "sha256:d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096", size = 73054, upload-time = "2026-02-18T22:15:17.958Z" },
 ]
 
 [[package]]
@@ -578,6 +578,7 @@ dev = [
     { name = "pylint" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
     { name = "ruff" },
     { name = "setuptools" },
@@ -592,7 +593,7 @@ requires-dist = [
     { name = "babelfish", specifier = "~=0.6.1" },
     { name = "guessit", specifier = "~=3.8.0" },
     { name = "requests", specifier = ">=2.33.1,<2.35.0" },
-    { name = "requests-cache", specifier = "~=1.3.1" },
+    { name = "requests-cache", specifier = "~=1.3.2" },
     { name = "setuptools-scm", specifier = ">=10.0.0" },
     { name = "teletype", specifier = "~=1.3.4" },
 ]
@@ -606,6 +607,7 @@ dev = [
     { name = "pylint", specifier = ">=4.0" },
     { name = "pytest", specifier = ">=9.0" },
     { name = "pytest-cov", specifier = ">=7.0" },
+    { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "pytest-rerunfailures", specifier = ">=16.0" },
     { name = "ruff", specifier = "~=0.15.12" },
     { name = "setuptools", specifier = ">=80.0.0" },
@@ -818,6 +820,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- mock provider endpoint calls in e2e tests so the e2e suite runs without live API dependencies
- add local provider coverage and tighten provider/endpoint behavior around cache flags, TVDb tokens, and fallback metadata
- clean up test typing for basedpyright and filter a dependency deprecation warning from url-normalize

## Tests
- basedpyright tests
- uv run ruff check mnamer tests
- uv run pytest