### PR TITLE
Remove future annotations imports

### DIFF
--- a/mnamer/language.py
+++ b/mnamer/language.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import dataclasses
 from typing import Any, Self, override
 
@@ -73,7 +71,7 @@ class Language:
         return self.a2
 
     @staticmethod
-    def ensure_valid_for_tvdb(language: Language | None):
+    def ensure_valid_for_tvdb(language: "Language | None"):
         valid = {
             "cs",
             "da",

--- a/mnamer/metadata.py
+++ b/mnamer/metadata.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import dataclasses
 import datetime as dt
 import re
@@ -100,7 +98,7 @@ class Metadata:
             value = str_title_case(value)
         return value
 
-    def update(self, metadata: Metadata):
+    def update(self, metadata: "Metadata"):
         """Overlays all none value from another Metadata instance."""
         for field in dataclasses.asdict(self).keys():
             value = getattr(metadata, field)

--- a/mnamer/providers.py
+++ b/mnamer/providers.py
@@ -1,7 +1,5 @@
 """Provides a high-level interface for metadata media providers."""
 
-from __future__ import annotations
-
 import datetime as dt
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
@@ -62,31 +60,31 @@ class Provider[M: Metadata](ABC):
     @staticmethod
     def provider_factory(
         provider: Literal[ProviderType.OMDB], settings: SettingStore
-    ) -> Omdb: ...
+    ) -> "Omdb": ...
     @overload
     @staticmethod
     def provider_factory(
         provider: Literal[ProviderType.TMDB], settings: SettingStore
-    ) -> Tmdb: ...
+    ) -> "Tmdb": ...
     @overload
     @staticmethod
     def provider_factory(
         provider: Literal[ProviderType.TVDB], settings: SettingStore
-    ) -> Tvdb: ...
+    ) -> "Tvdb": ...
     @overload
     @staticmethod
     def provider_factory(
         provider: Literal[ProviderType.TVMAZE], settings: SettingStore
-    ) -> TvMaze: ...
+    ) -> "TvMaze": ...
     @overload
     @staticmethod
     def provider_factory(
         provider: ProviderType, settings: SettingStore
-    ) -> Omdb | Tmdb | Tvdb | TvMaze: ...
+    ) -> "Omdb | Tmdb | Tvdb | TvMaze": ...
     @staticmethod
     def provider_factory(
         provider: ProviderType, settings: SettingStore
-    ) -> Omdb | Tmdb | Tvdb | TvMaze:
+    ) -> "Omdb | Tmdb | Tvdb | TvMaze":
         """Factory function for DB Provider concrete classes."""
         provider_classes: dict[
             ProviderType, type[Omdb] | type[Tmdb] | type[Tvdb] | type[TvMaze]

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import datetime as dt
 from pathlib import Path
 from shutil import move
@@ -68,7 +66,7 @@ class Target:
         cls._providers.clear()
 
     @staticmethod
-    def _matches_media(target: Target) -> bool:
+    def _matches_media(target: "Target") -> bool:
         if not target._settings.media:
             return True
         else:

--- a/mnamer/types.py
+++ b/mnamer/types.py
@@ -1,7 +1,5 @@
 """Enum type definitions."""
 
-from __future__ import annotations
-
 from enum import Enum
 from typing import Self
 


### PR DESCRIPTION
## Summary
- remove obsolete `from __future__ import annotations` imports now that the project targets Python 3.12+
- quote the remaining forward references that need deferred evaluation

## Tests
- `uv run pytest -m local`
- `uv run ruff check mnamer tests`
- `uv run mypy mnamer tests`