### PR TITLE
Fix str_title_case skipping later lowercase-exception words after a leading occurrence

### DIFF
--- a/mnamer/utils.py
+++ b/mnamer/utils.py
@@ -467,7 +467,7 @@ def str_title_case(s: str) -> str:
         for pos in findall(string_lower, exception):
             is_start = pos < 2
             if is_start:
-                break
+                continue
             prev_char = string_lower[pos - 1]
             is_left_partitioned = prev_char in padding_chars
             word_length = len(exception)

--- a/tests/local/test_utils.py
+++ b/tests/local/test_utils.py
@@ -698,6 +698,21 @@ def test_str_title_case__lower__ends_with(s: str):
     assert actual == expected
 
 
+@pytest.mark.parametrize(
+    ("s", "expected"),
+    (
+        ("the cat in the hat", "The Cat in the Hat"),
+        ("THE CAT IN THE HAT", "The Cat in the Hat"),
+        ("a man and a plan", "A Man and a Plan"),
+    ),
+)
+def test_str_title_case__lower__repeated_after_start(s: str, expected: str):
+    # The leading exception word stays capitalized, but a later occurrence of
+    # the same word must still be lowercased.
+    actual = str_title_case(s)
+    assert actual == expected
+
+
 @pytest.mark.parametrize("s", ("at the theatre", "AT THE THEATRE"))
 def test_str_title_case__lower__only_whole_words(s: str):
     expected = "At the Theatre"  # theatre prefixed with 'the'


### PR DESCRIPTION
## Problem

In `str_title_case`, the lowercase-exception pass bails out of the whole
loop the first time a match is found at the start of the string:

```python
for pos in findall(string_lower, exception):
    is_start = pos < 2
    if is_start:
        break        # aborts every remaining occurrence of this word
```

`findall` yields *every* position of the exception word. The intent of the
`is_start` guard is to leave the leading word capitalized — but `break`
abandons all later occurrences too, so a small word that appears once at the
start and again later never gets lowercased:

```python
>>> from mnamer.utils import str_title_case
>>> str_title_case("the cat in the hat")
'The Cat in The Hat'      # expected: 'The Cat in the Hat'
>>> str_title_case("a man and a plan")
'A Man and A Plan'        # expected: 'A Man and a Plan'
```

## Fix

Use `continue` instead of `break`, so only the leading occurrence is skipped
and later ones are still processed. One-word change.

## Tests

Added `test_str_title_case__lower__repeated_after_start` covering a
lowercase-exception word that recurs after the start (`the cat in the hat`,
its uppercase variant, and `a man and a plan`). Verified it fails on the
previous code and passes with the fix. The full local suite (347 tests)
passes, and `ruff check` / `ruff format --check` are clean.
