### PR TITLE
Add AKA to tvmaze lookups

### DIFF
--- a/mnamer/endpoints.py
+++ b/mnamer/endpoints.py
@@ -538,6 +538,7 @@ def tvmaze_show(
     """
     url = f"http://api.tvmaze.com/shows/{id_tvmaze}"
     parameters: dict[str, Any] = {}
+    parameters["embed"] = "akas"
     if embed_episodes:
         parameters["embed"] = "episodes"
     status, content = request_json(url, parameters, cache=cache)
@@ -614,7 +615,7 @@ def tvmaze_show_lookup(
     if not [id_imdb, id_tvdb].count(None) == 1:
         raise MnamerException("id_imdb and id_tvdb are mutually exclusive")
     url = "http://api.tvmaze.com/lookup/shows"
-    parameters: dict[str, Any] = {"imdb": id_imdb, "thetvdb": id_tvdb}
+    parameters: dict[str, Any] = {"imdb": id_imdb, "thetvdb": id_tvdb, "embed": "akas"}
     status, content = request_json(url, parameters, cache=cache)
     if status == 443 and attempt <= MAX_RETRIES:  # pragma: no cover
         sleep(attempt * 2)

--- a/mnamer/endpoints.py
+++ b/mnamer/endpoints.py
@@ -112,10 +112,21 @@ class TvMazeExternals(TypedDict):
     imdb: NotRequired[str | None]
 
 
+class TvMazeAka(TypedDict):
+    name: str
+    country: dict[str, str] | None
+
+
+class TvMazeEmbedded(TypedDict, total=False):
+    akas: list[TvMazeAka]
+
+
 class TvMazeShow(TypedDict):
     id: int
     name: str
     externals: TvMazeExternals
+    language: NotRequired[str | None]
+    _embedded: NotRequired[TvMazeEmbedded]
 
 
 class TvMazeSearchEntry(TypedDict):

--- a/mnamer/providers.py
+++ b/mnamer/providers.py
@@ -453,7 +453,7 @@ class TvMaze(Provider[MetadataEpisode]):
         episode: int | None,
         language: Language | None = None,
     ) -> Iterator[MetadataEpisode]:
-        series_data = tvmaze_show(id_tvmaze)
+        series_data = tvmaze_show(id_tvmaze, cache=self.cache)
         episode_data = tvmaze_episode_by_number(id_tvmaze, season, episode)
         id_tvdb = self._opt_str(series_data["externals"].get("thetvdb"))
         yield self._transform_meta(
@@ -469,13 +469,16 @@ class TvMaze(Provider[MetadataEpisode]):
     ) -> Iterator[MetadataEpisode]:
         assert id_tvmaze or id_tvdb
         if id_tvmaze:
-            series_data = tvmaze_show(id_tvmaze)
+            series_data = tvmaze_show(id_tvmaze, cache=self.cache)
             query_id_tvmaze = id_tvmaze
             query_id_tvdb = self._opt_str(series_data["externals"].get("thetvdb"))
         else:
-            series_data = tvmaze_show_lookup(id_tvdb=id_tvdb)
-            query_id_tvmaze = str(series_data["id"])
+            lookup_data = tvmaze_show_lookup(id_tvdb=id_tvdb)
+            query_id_tvmaze = str(lookup_data["id"])
             query_id_tvdb = id_tvdb
+            series_data = tvmaze_show(
+                query_id_tvmaze, cache=self.cache
+            )  # re-fetch with AKAs embedded
         episode_data = tvmaze_episodes_by_date(query_id_tvmaze, air_date)
         for episode_entry in episode_data:
             yield self._transform_meta(
@@ -493,12 +496,15 @@ class TvMaze(Provider[MetadataEpisode]):
         assert id_tvmaze or id_tvdb
         if id_tvmaze:
             query_id_tvmaze = id_tvmaze
-            series_data = tvmaze_show(id_tvmaze)
+            series_data = tvmaze_show(id_tvmaze, cache=self.cache)
             query_id_tvdb = self._opt_str(series_data["externals"].get("thetvdb"))
         else:
-            series_data = tvmaze_show_lookup(id_tvdb=id_tvdb)
+            lookup_data = tvmaze_show_lookup(id_tvdb=id_tvdb)
+            query_id_tvmaze = str(lookup_data["id"])
             query_id_tvdb = id_tvdb
-            query_id_tvmaze = str(series_data["id"])
+            series_data = tvmaze_show(
+                query_id_tvmaze, cache=self.cache
+            )  # re-fetch with AKAs embedded
         episode_data = tvmaze_show_episodes_list(query_id_tvmaze)
         for episode_entry in episode_data:
             meta = self._transform_meta(
@@ -518,12 +524,13 @@ class TvMaze(Provider[MetadataEpisode]):
         language: Language | None = None,
     ) -> Iterator[MetadataEpisode]:
         assert season
-        series_data = tvmaze_show_search(series)
+        series_data = tvmaze_show_search(series, cache=self.cache)
         for idx, search_entry in enumerate(series_data):
             if idx >= 3:
                 break
             series_entry = search_entry["show"]
             id_tvmaze = str(series_entry["id"])
+            series_entry = tvmaze_show(id_tvmaze, cache=self.cache)
             try:
                 episode_entry = tvmaze_episode_by_number(id_tvmaze, season, episode)
             except MnamerNotFoundException:
@@ -545,12 +552,13 @@ class TvMaze(Provider[MetadataEpisode]):
         language: Language | None = None,
     ) -> Iterator[MetadataEpisode]:
         assert series
-        series_data = tvmaze_show_search(series)
+        series_data = tvmaze_show_search(series, cache=self.cache)
         for idx, search_entry in enumerate(series_data):
             if idx >= 3:
                 break
             series_entry = search_entry["show"]
             id_tvmaze = str(series_entry["id"])
+            series_entry = tvmaze_show(id_tvmaze, cache=self.cache)
             episode_data = tvmaze_show_episodes_list(id_tvmaze)
             for episode_entry in episode_data:
                 id_tvdb = self._opt_str(series_entry["externals"].get("thetvdb"))
@@ -604,11 +612,8 @@ class TvMaze(Provider[MetadataEpisode]):
                     if country.get("code") in target_countries:
                         return aka["name"]
 
-                if language.a2 == "en":
-                    show_language = (series_entry.get("language") or "").lower()
-                    if show_language not in ("english", "en", ""):
-                        for aka in akas:
-                            if aka.get("country") is None:
-                                return aka["name"]
+                # country: null fallback removed — TVMaze defines these as
+                # original-country aliases, not English/international titles.
+                # See: https://github.com/jkwill87/mnamer/pull/375
 
         return series_entry["name"]

--- a/mnamer/providers.py
+++ b/mnamer/providers.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from os import environ
 from typing import Literal, Self, overload, override
+from warnings import warn
 
 from mnamer.endpoints import (
     TvMazeEpisode,
@@ -32,6 +33,26 @@ from mnamer.metadata import Metadata, MetadataEpisode, MetadataMovie
 from mnamer.setting_store import SettingStore
 from mnamer.types import MediaType, ProviderType
 from mnamer.utils import parse_date, year_parse, year_range_parse
+
+_LANGUAGE_COUNTRIES: dict[str, frozenset[str]] = {
+    "en": frozenset({"US", "GB", "AU", "CA", "NZ", "IE"}),
+    "de": frozenset({"DE", "AT", "CH"}),
+    "fr": frozenset({"FR", "BE", "CH", "CA"}),
+    "es": frozenset({"ES", "MX", "AR", "CO", "CL"}),
+    "pt": frozenset({"PT", "BR"}),
+    "it": frozenset({"IT", "CH"}),
+    "nl": frozenset({"NL", "BE"}),
+    "ru": frozenset({"RU"}),
+    "ja": frozenset({"JP"}),
+    "ko": frozenset({"KR"}),
+    "zh": frozenset({"CN", "TW", "HK"}),
+    "sv": frozenset({"SE"}),
+    "no": frozenset({"NO"}),
+    "da": frozenset({"DK"}),
+    "fi": frozenset({"FI"}),
+    "pl": frozenset({"PL"}),
+    "tr": frozenset({"TR"}),
+}
 
 
 class Provider[M: Metadata](ABC):
@@ -396,22 +417,28 @@ class TvMaze(Provider[MetadataEpisode]):
     def search(self, query: MetadataEpisode) -> Iterator[MetadataEpisode]:
         if query.id_tvmaze and query.season and query.episode:
             yield from self._lookup_with_tmaze_id_and_season_and_episode(
-                query.id_tvmaze, query.season, query.episode
+                query.id_tvmaze, query.season, query.episode, query.language
             )
         elif (query.id_tvmaze or query.id_tvdb) and query.date:
             yield from self._lookup_with_id_and_date(
-                query.id_tvmaze, query.id_tvdb, query.date
+                query.id_tvmaze, query.id_tvdb, query.date, query.language
             )
         elif query.id_tvmaze or query.id_tvdb:
             yield from self._lookup_with_id(
-                query.id_tvmaze, query.id_tvdb, query.season, query.episode
+                query.id_tvmaze,
+                query.id_tvdb,
+                query.season,
+                query.episode,
+                query.language,
             )
         elif query.series and query.season and query.episode:
             yield from self._search_with_season_and_episode(
-                query.series, query.season, query.episode
+                query.series, query.season, query.episode, query.language
             )
         elif query.series:
-            yield from self._search(query.series, query.season, query.episode)
+            yield from self._search(
+                query.series, query.season, query.episode, query.language
+            )
         else:
             raise MnamerNotFoundException
 
@@ -420,15 +447,25 @@ class TvMaze(Provider[MetadataEpisode]):
         return str(value) if value else None
 
     def _lookup_with_tmaze_id_and_season_and_episode(
-        self, id_tvmaze: str, season: int | None, episode: int | None
+        self,
+        id_tvmaze: str,
+        season: int | None,
+        episode: int | None,
+        language: Language | None = None,
     ) -> Iterator[MetadataEpisode]:
         series_data = tvmaze_show(id_tvmaze)
         episode_data = tvmaze_episode_by_number(id_tvmaze, season, episode)
         id_tvdb = self._opt_str(series_data["externals"].get("thetvdb"))
-        yield self._transform_meta(id_tvmaze, id_tvdb, series_data, episode_data)
+        yield self._transform_meta(
+            id_tvmaze, id_tvdb, series_data, episode_data, language
+        )
 
     def _lookup_with_id_and_date(
-        self, id_tvmaze: str | None, id_tvdb: str | None, air_date: dt.date
+        self,
+        id_tvmaze: str | None,
+        id_tvdb: str | None,
+        air_date: dt.date,
+        language: Language | None = None,
     ) -> Iterator[MetadataEpisode]:
         assert id_tvmaze or id_tvdb
         if id_tvmaze:
@@ -442,7 +479,7 @@ class TvMaze(Provider[MetadataEpisode]):
         episode_data = tvmaze_episodes_by_date(query_id_tvmaze, air_date)
         for episode_entry in episode_data:
             yield self._transform_meta(
-                query_id_tvmaze, query_id_tvdb, series_data, episode_entry
+                query_id_tvmaze, query_id_tvdb, series_data, episode_entry, language
             )
 
     def _lookup_with_id(
@@ -451,6 +488,7 @@ class TvMaze(Provider[MetadataEpisode]):
         id_tvdb: str | None,
         season: int | None,
         episode: int | None,
+        language: Language | None = None,
     ) -> Iterator[MetadataEpisode]:
         assert id_tvmaze or id_tvdb
         if id_tvmaze:
@@ -464,7 +502,7 @@ class TvMaze(Provider[MetadataEpisode]):
         episode_data = tvmaze_show_episodes_list(query_id_tvmaze)
         for episode_entry in episode_data:
             meta = self._transform_meta(
-                query_id_tvmaze, query_id_tvdb, series_data, episode_entry
+                query_id_tvmaze, query_id_tvdb, series_data, episode_entry, language
             )
             if season is not None and season != meta.season:
                 continue
@@ -473,7 +511,11 @@ class TvMaze(Provider[MetadataEpisode]):
             yield meta
 
     def _search_with_season_and_episode(
-        self, series: str, season: int | None, episode: int | None
+        self,
+        series: str,
+        season: int | None,
+        episode: int | None,
+        language: Language | None = None,
     ) -> Iterator[MetadataEpisode]:
         assert season
         series_data = tvmaze_show_search(series)
@@ -486,7 +528,9 @@ class TvMaze(Provider[MetadataEpisode]):
                 episode_entry = tvmaze_episode_by_number(id_tvmaze, season, episode)
             except MnamerNotFoundException:
                 continue
-            meta = self._transform_meta(id_tvmaze, None, series_entry, episode_entry)
+            meta = self._transform_meta(
+                id_tvmaze, None, series_entry, episode_entry, language
+            )
             if season != meta.season:
                 continue
             if episode is not None and episode != meta.episode:
@@ -494,7 +538,11 @@ class TvMaze(Provider[MetadataEpisode]):
             yield meta
 
     def _search(
-        self, series: str, season: int | None, episode: int | None
+        self,
+        series: str,
+        season: int | None,
+        episode: int | None,
+        language: Language | None = None,
     ) -> Iterator[MetadataEpisode]:
         assert series
         series_data = tvmaze_show_search(series)
@@ -507,7 +555,7 @@ class TvMaze(Provider[MetadataEpisode]):
             for episode_entry in episode_data:
                 id_tvdb = self._opt_str(series_entry["externals"].get("thetvdb"))
                 meta = self._transform_meta(
-                    id_tvmaze, id_tvdb, series_entry, episode_entry
+                    id_tvmaze, id_tvdb, series_entry, episode_entry, language
                 )
                 if season is not None and season != meta.season:
                     continue
@@ -521,6 +569,7 @@ class TvMaze(Provider[MetadataEpisode]):
         id_tvdb: str | None,
         series_entry: TvMazeShow,
         episode_entry: TvMazeEpisode,
+        language: Language | None = None,
     ) -> MetadataEpisode:
         airdate = episode_entry["airdate"]
         return MetadataEpisode(
@@ -529,7 +578,37 @@ class TvMaze(Provider[MetadataEpisode]):
             id_tvdb=id_tvdb or None,
             id_tvmaze=id_tvmaze or None,
             season=episode_entry["season"],
-            series=series_entry["name"],
+            series=TvMaze._preferred_name(series_entry, language),
             synopsis=episode_entry["summary"] or None,
             title=episode_entry["name"] or None,
         )
+
+    @staticmethod
+    def _preferred_name(series_entry: TvMazeShow, language: Language | None) -> str:
+        if language:
+            if language.a2 not in _LANGUAGE_COUNTRIES:
+                warn(
+                    f"No TVMaze country mapping for language '{language.a2}'. "
+                    f"AKA lookup skipped; primary title will be used. "
+                    f"To add support, open a PR adding '{language.a2}' to "
+                    f"_LANGUAGE_COUNTRIES in mnamer/providers.py.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            else:
+                akas = series_entry.get("_embedded", {}).get("akas", []) or []
+                target_countries = _LANGUAGE_COUNTRIES[language.a2]
+
+                for aka in akas:
+                    country = aka.get("country") or {}
+                    if country.get("code") in target_countries:
+                        return aka["name"]
+
+                if language.a2 == "en":
+                    show_language = (series_entry.get("language") or "").lower()
+                    if show_language not in ("english", "en", ""):
+                        for aka in akas:
+                            if aka.get("country") is None:
+                                return aka["name"]
+
+        return series_entry["name"]

--- a/tests/network/test_providers__tvmaze.py
+++ b/tests/network/test_providers__tvmaze.py
@@ -177,8 +177,8 @@ def test_search__no_hits(provider: TvMaze):
         next(provider.search(query))
 
 
-def test_search__foreign_show_english_aka_with_language():
-    """Foreign show returns English AKA name when language=en."""
+def test_search__foreign_show_returns_primary_name_when_no_english_aka():
+    """Show with only a country=null AKA returns primary name for --language=en."""
     provider = TvMaze(cache=False)
     query = MetadataEpisode(
         id_tvmaze="59772",
@@ -188,7 +188,7 @@ def test_search__foreign_show_english_aka_with_language():
     )
     results = list(provider.search(query))
     assert results
-    assert results[0].series == "Faster Than Fear"
+    assert results[0].series == "Schneller Als Die Angst"
 
 
 def test_search__foreign_show_primary_name_without_language():
@@ -204,8 +204,6 @@ def test_search__foreign_show_primary_name_without_language():
     assert results[0].series == "Schneller Als Die Angst"
 
 
-# English AKA with country: null fallback (Faster than Fear) — already have this
-# Polish show with no country-coded AKAs — verify primary name returned unchanged
 def test_search__show_with_ambiguous_akas_returns_primary():
     """Show with only country=null AKAs returns primary name even with language=en."""
     provider = TvMaze(cache=False)

--- a/tests/network/test_providers__tvmaze.py
+++ b/tests/network/test_providers__tvmaze.py
@@ -1,6 +1,7 @@
 import pytest
 
 from mnamer.exceptions import MnamerNotFoundException
+from mnamer.language import Language
 from mnamer.metadata import MetadataEpisode
 from mnamer.providers import TvMaze
 from tests import EPISODE_META, JUNK_TEXT, TEST_DATE, EpisodeMeta
@@ -174,3 +175,130 @@ def test_search__no_hits(provider: TvMaze):
     query = MetadataEpisode()
     with pytest.raises(MnamerNotFoundException):
         next(provider.search(query))
+
+
+def test_search__foreign_show_english_aka_with_language():
+    """Foreign show returns English AKA name when language=en."""
+    provider = TvMaze(cache=False)
+    query = MetadataEpisode(
+        id_tvmaze="59772",
+        season=1,
+        episode=1,
+        language=Language.parse("en"),
+    )
+    results = list(provider.search(query))
+    assert results
+    assert results[0].series == "Faster Than Fear"
+
+
+def test_search__foreign_show_primary_name_without_language():
+    """Foreign show returns primary name when no language set."""
+    provider = TvMaze(cache=False)
+    query = MetadataEpisode(
+        id_tvmaze="59772",
+        season=1,
+        episode=1,
+    )
+    results = list(provider.search(query))
+    assert results
+    assert results[0].series == "Schneller Als Die Angst"
+
+
+# English AKA with country: null fallback (Faster than Fear) — already have this
+# Polish show with no country-coded AKAs — verify primary name returned unchanged
+def test_search__show_with_ambiguous_akas_returns_primary():
+    """Show with only country=null AKAs returns primary name even with language=en."""
+    provider = TvMaze(cache=False)
+    query = MetadataEpisode(
+        id_tvmaze="92273",  # Morfeusz — AKAs have no country codes
+        season=1,
+        episode=1,
+        language=Language.parse("en"),
+    )
+    results = list(provider.search(query))
+    assert results
+    assert results[0].series == "Morfeusz"  # should NOT return "Morfeus"
+
+
+def test_search__korean_show_returns_korean_aka():
+    """Korean show returns Korean-script AKA when language=ko."""
+    provider = TvMaze(cache=False)
+    query = MetadataEpisode(
+        id_tvmaze="92451",
+        season=1,
+        episode=1,
+        language=Language.parse("ko"),
+    )
+    results = list(provider.search(query))
+    assert results
+    assert results[0].series == "검사실의 제안"
+
+
+def test_search__korean_show_returns_primary_without_language():
+    """Korean show returns primary English name when no language set."""
+    provider = TvMaze(cache=False)
+    query = MetadataEpisode(
+        id_tvmaze="92451",
+        season=1,
+        episode=1,
+    )
+    results = list(provider.search(query))
+    assert results
+    assert results[0].series == "The Prosecutor's Office's Proposal"
+
+
+def test_search__show_with_no_akas_returns_primary_name():
+    """Show with no AKAs returns primary name regardless of requested language."""
+    provider = TvMaze(cache=False)
+    query = MetadataEpisode(
+        id_tvmaze="50",  # The Lottery — no AKAs, language: English
+        season=1,
+        episode=1,
+        language=Language.parse("en"),
+    )
+    results = list(provider.search(query))
+    assert results
+    assert results[0].series == "The Lottery"
+
+
+def test_search__unsupported_language_warns_and_returns_primary():
+    """Requesting a language with no _LANGUAGE_COUNTRIES mapping warns and returns primary name."""
+    provider = TvMaze(cache=False)
+    query = MetadataEpisode(
+        id_tvmaze="50",  # The Lottery — simple English show, no AKAs
+        season=1,
+        episode=1,
+        language=Language.parse("ar"),  # Arabic — not in _LANGUAGE_COUNTRIES
+    )
+    with pytest.warns(UserWarning, match="No TVMaze country mapping for language 'ar'"):
+        results = list(provider.search(query))
+    assert results
+    assert results[0].series == "The Lottery"
+
+
+def test_search__no_matching_language_aka_returns_primary():
+    """Show with AKAs but none matching the requested language returns primary name."""
+    provider = TvMaze(cache=False)
+    query = MetadataEpisode(
+        id_tvmaze="92451",  # The Prosecutor's Office's Proposal — has KR AKA only
+        season=1,
+        episode=1,
+        language=Language.parse("de"),  # German — no DE AKA exists
+    )
+    results = list(provider.search(query))
+    assert results
+    assert results[0].series == "The Prosecutor's Office's Proposal"
+
+
+def test_search__multiple_akas_same_country_returns_first():
+    """When multiple AKAs exist for the same country, the first one is returned."""
+    provider = TvMaze(cache=False)
+    query = MetadataEpisode(
+        id_tvmaze="2",  # Person of Interest — two RU AKAs: 'В поле зрения' and 'Подозреваемые'
+        season=1,
+        episode=1,
+        language=Language.parse("ru"),
+    )
+    results = list(provider.search(query))
+    assert results
+    assert results[0].series == "В Поле Зрения"  # first RU AKA wins


### PR DESCRIPTION
If the language flag is passed and an AKA exists use that for names.

I have added some of the more popular language/country combinations with a warning when missing to create a PR.