### PR TITLE
Adding "series_year" Variable to Episode Metadata

### DIFF
--- a/mnamer/endpoints.py
+++ b/mnamer/endpoints.py
@@ -78,6 +78,7 @@ class TvdbLinks(TypedDict):
 class TvdbSeriesData(TypedDict):
     id: int
     series_name: str
+    first_aired: NotRequired[str]
 
 
 class TvdbSeriesResponse(TypedDict):
@@ -116,6 +117,7 @@ class TvMazeShow(TypedDict):
     id: int
     name: str
     externals: TvMazeExternals
+    premiered: NotRequired[str | None]
 
 
 class TvMazeSearchEntry(TypedDict):

--- a/mnamer/metadata.py
+++ b/mnamer/metadata.py
@@ -149,6 +149,7 @@ class MetadataEpisode(Metadata):
     """
 
     series: str | None = None
+    series_year: str | None = None
     season: int | None = None
     episode: int | None = None
     date: dt.date | None = None
@@ -179,6 +180,7 @@ class MetadataEpisode(Metadata):
             "episode": int,
             "season": int,
             "series": fn_pipe(str_replace_slashes, str_title_case),
+            "series_year": year_parse,
             "title": fn_pipe(str_replace_slashes, str_title_case),
         }
         converter: Callable[[Any], Any] | None = converter_map.get(key)

--- a/mnamer/providers.py
+++ b/mnamer/providers.py
@@ -316,6 +316,7 @@ class Tvdb(Provider[MetadataEpisode]):
                         id_tvdb=id_tvdb,
                         season=entry["aired_season"],
                         series=series_data["data"]["series_name"],
+                        series_year=series_data["data"].get("first_aired"),
                         language=language,
                         synopsis=(entry["overview"] or "")
                         .replace("\r\n", "")
@@ -532,4 +533,5 @@ class TvMaze(Provider[MetadataEpisode]):
             series=series_entry["name"],
             synopsis=episode_entry["summary"] or None,
             title=episode_entry["name"] or None,
+            series_year=series_entry.get("premiered"),
         )

--- a/tests/local/test_metadata.py
+++ b/tests/local/test_metadata.py
@@ -60,6 +60,12 @@ def test_metadata_episode__convert_episode():
     assert metadata.episode == 1
 
 
+@pytest.mark.parametrize("value", ["1987", "1987-10-01"])
+def test_metadata_episode__convert_series_year(value):
+    metadata = MetadataEpisode(series_year=value)
+    assert metadata.series_year == 1987
+
+
 def test_metadata_episode__format_default():
     metadata = MetadataEpisode(series="Spongebob Squarepants", season=4, episode=4)
     actual = format(metadata)

--- a/tests/local/test_providers.py
+++ b/tests/local/test_providers.py
@@ -28,7 +28,9 @@ TMDB_MOVIE = {
     "imdb_id": "tt1234567",
 }
 
-TVDB_SERIES = {"data": {"id": 100, "series_name": "Example Series"}}
+TVDB_SERIES = {
+    "data": {"id": 100, "series_name": "Example Series", "first_aired": "2019-01-01"}
+}
 
 TVDB_EPISODE = {
     "first_aired": "2020-01-02",
@@ -42,6 +44,7 @@ TVMAZE_SHOW = {
     "id": 200,
     "name": "Example Series",
     "externals": {"thetvdb": 100, "imdb": "tt7654321"},
+    "premiered": "2019-01-01",
 }
 
 TVMAZE_EPISODE = {
@@ -227,6 +230,7 @@ def test_tvdb_search__lazy_login_and_id_search(mocker):
     assert result.series == "Example Series"
     assert result.title == "Episode Two"
     assert result.id_tvdb == "100"
+    assert result.series_year == 2019
     mock_login.assert_called_once_with("key")
     mock_series.assert_called_once_with("token", "100", language=None, cache=True)
     mock_episodes.assert_called_once_with(
@@ -324,6 +328,7 @@ def test_tvmaze_search__tvmaze_id_season_episode(mocker):
     assert result.title == "Episode Two"
     assert result.id_tvmaze == "200"
     assert result.id_tvdb == "100"
+    assert result.series_year == 2019
 
 
 def test_tvmaze_search__tvdb_id_date_lookup(mocker):


### PR DESCRIPTION
This PR introduces a "series_year" variable for use with the "episode_directory" variable in the config file. For shows that have been rebooted / live-adapted, the premiere date year of the show is a primary identifier for tools like Plex/Jellyfin to correctly display the right show, for example:

- Avatar - The Last Airbender (2005) vs (2024)
- Teen Titans (2003) vs (2013)

I utilized Claude Code to perform this PR as I am a JS/Swift developer and this is not my expertise but it appears that these variables are available in both API providers through the same requests that power the app today!