### PR TITLE
fix(target): keep container when stripping subtitle language suffix

### DIFF
--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -152,12 +152,20 @@ class Target:
 
     def _parse(self, file_path: Path):
         path_data: dict[str, Any] = {"language": self._settings.language}
-        if is_subtitle(self.source):
+        suffixed_sub_language: Language | None = None
+        if is_subtitle(self.source) and self.source.stem[-3:-2] == ".":
             try:
-                path_data["language"] = Language.parse(self.source.stem[-2:])
-                file_path = Path(self.source.parent, self.source.stem[:-2])
+                suffixed_sub_language = Language.parse(self.source.stem[-2:])
             except MnamerException:
                 pass
+            else:
+                path_data["language"] = suffixed_sub_language
+                # strip the language tag but keep the container suffix so the
+                # renamed file does not lose its extension
+                file_path = Path(
+                    self.source.parent,
+                    f"{self.source.stem[:-3]}{self.source.suffix}",
+                )
         options = {"type": self._settings.media, "language": path_data["language"]}
         raw_data = dict(guessit(str(file_path), options))
         if isinstance(raw_data.get("season"), list):
@@ -211,7 +219,9 @@ class Target:
             except MnamerException:
                 pass
         try:
-            self.metadata.language_sub = path_data.get("subtitle_language")
+            self.metadata.language_sub = suffixed_sub_language or path_data.get(
+                "subtitle_language"
+            )
         except MnamerException:
             pass
         if isinstance(self.metadata, MetadataMovie):

--- a/tests/local/test_target.py
+++ b/tests/local/test_target.py
@@ -112,6 +112,22 @@ def test_ambiguous_subtitle_language():
     assert target.metadata.language is None
 
 
+def test_parse__language_suffixed_subtitle_keeps_container():
+    """A `name.<lang>.srt` subtitle keeps its language tag and extension."""
+    target = Target(Path("Subs/ninja.turtles.s01e04.en.srt"), SettingStore())
+    assert target.metadata.container == ".srt"
+    assert target.metadata.language_sub is not None
+    assert target.metadata.language_sub.a2 == "en"
+    assert target.metadata.extension == ".en.srt"
+
+
+def test_destination__language_suffixed_subtitle_keeps_extension():
+    """A language-suffixed subtitle is not renamed to a bare, extension-less name."""
+    settings = SettingStore(batch=True, media=MediaType.EPISODE)
+    target = Target(Path("Subs/ninja.turtles.s01e04.en.srt"), settings)
+    assert target.destination.name.endswith(".en.srt")
+
+
 def test_destination__simple():
     pass  # TODO
 


### PR DESCRIPTION
Closes #266

`Target._parse` stripped the last two characters from the source *stem* to remove a subtitle language tag, which also discarded the container suffix — so `metadata.container` came from an empty suffix and `dir/filename.en.srt` was renamed to `newdir/Cleaned Name.` with no language and no extension.

Now only a genuine `.<lang>` tag is stripped, the original suffix is re-attached, and the parsed language is carried into `metadata.language_sub` so `Metadata.extension` reproduces `.en.srt`.

Two regression tests in `tests/local/test_target.py` fail on `main` (`Ninja Turtles - S01E04.`) and pass with the fix.