### PR TITLE
fix(utils): keep dotted acronyms uppercase in str_title_case

### DIFF
--- a/mnamer/utils.py
+++ b/mnamer/utils.py
@@ -474,7 +474,12 @@ def str_title_case(s: str) -> str:
             ends = pos + word_length == string_length
             next_char = "" if ends else string_lower[pos + word_length]
             is_right_partitioned = not ends and next_char in padding_chars
-            if is_left_partitioned and is_right_partitioned:
+            # a single letter flanked by dots is an acronym component, e.g. the
+            # 'a' in "S.W.A.T.", not a standalone word to lowercase
+            is_acronym_letter = (
+                word_length == 1 and prev_char == "." and next_char == "."
+            )
+            if is_left_partitioned and is_right_partitioned and not is_acronym_letter:
                 s = s[:pos] + exception.lower() + s[pos + word_length :]
 
     # process uppercase transformations

--- a/tests/local/test_utils.py
+++ b/tests/local/test_utils.py
@@ -720,6 +720,20 @@ def test_str_title_case__lower__only_whole_words(s: str):
     assert actual == expected
 
 
+@pytest.mark.parametrize(
+    ("s", "expected"),
+    (
+        ("S.W.A.T.", "S.W.A.T."),
+        ("M.A.S.H.", "M.A.S.H."),
+        ("s.w.a.t.", "S.W.A.T."),
+    ),
+)
+def test_str_title_case__lower__dotted_acronym(s: str, expected: str):
+    # a single letter between dots is part of an acronym, not a standalone word
+    actual = str_title_case(s)
+    assert actual == expected
+
+
 @pytest.mark.parametrize("s", ("world war ii", "WORLD WAR II"))
 def test_str_title_case__upper(s: str):
     expected = "World War II"


### PR DESCRIPTION
Closes #297

`str_title_case` rendered `S.W.A.T.` as `S.W.a.T.` (and `M.A.S.H.` as `M.a.S.H.`): `.` is in `padding_chars`, so the single-letter lowercase exception `a` looked left- and right-partitioned like a standalone word. The lowercase transformation is now skipped when a one-letter exception is flanked by dots; multi-word titles are unchanged.

Regression test `test_str_title_case__lower__dotted_acronym` fails without the fix and passes with it; `tests/local/test_utils.py` is green (198 passed).
