### PR TITLE
Improve match UX, streaming, resolution, and several filename parsing fixes

### DIFF
--- a/mnamer/frontends.py
+++ b/mnamer/frontends.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import override
 
 from mnamer import tty
@@ -63,6 +64,7 @@ class Frontend(ABC):
 class Cli(Frontend):
     success_count: int
     total_count: int
+    _exclude_paths: set[Path]
 
     def __init__(self, settings: SettingStore):
         super().__init__(settings)
@@ -71,11 +73,17 @@ class Cli(Frontend):
             raise SystemExit(2)
         self.success_count = 0
         self.total_count = 0
+        self._exclude_paths = set()
 
     @override
     def launch(self) -> None:
         tty.msg("Starting mnamer", MessageType.HEADING)
-        with TargetLookahead(Target.iter_paths(self.settings)) as lookahead:
+        # Mutable set consulted by the live crawl so relocated outputs are not
+        # rediscovered later in the same recursive walk.
+        self._exclude_paths = set()
+        with TargetLookahead(
+            Target.iter_paths(self.settings, self._exclude_paths)
+        ) as lookahead:
             prepared = lookahead.prime()
             if prepared is None:
                 tty.msg("", debug=True)
@@ -106,7 +114,7 @@ class Cli(Frontend):
         if (
             self.settings.skip_correct
             and matches
-            and target.preview_filename(matches[0]) == target.source.name
+            and target.destination_for(matches[0]) == target.source.resolve()
         ):
             tty.msg(
                 "skipping (--skip-correct, already matches top hit)",
@@ -181,6 +189,10 @@ class Cli(Frontend):
             f"moving to {target.destination.absolute()}",
             MessageType.SUCCESS,
         )
+        destination = target.destination.resolve()
+        # Exclude before/whether the move succeeds so a live recursive crawl
+        # cannot pick up outputs written into the scanned tree.
+        self._exclude_paths.add(destination)
         if self.settings.test:
             self.success_count += 1
             return

--- a/mnamer/frontends.py
+++ b/mnamer/frontends.py
@@ -116,8 +116,6 @@ class Cli(Frontend):
         try:
             if self.settings.batch:
                 match = matches[0] if matches else target.metadata
-            elif not matches:
-                match = tty.metadata_guess(target.metadata, target)
             else:
                 match = tty.metadata_prompt(matches, target)
         except MnamerSkipException:

--- a/mnamer/frontends.py
+++ b/mnamer/frontends.py
@@ -22,7 +22,7 @@ class Frontend(ABC):
 
     def __init__(self, settings: SettingStore):
         self.settings = settings
-        self.targets = Target.populate_paths(self.settings)
+        self.targets = []
         tty.configure(self.settings)
         self._handle_directives()
         self._print_configuration()
@@ -54,10 +54,7 @@ class Frontend(ABC):
         tty.msg("\nsettings", debug=True)
         tty.msg(self.settings.as_dict(), debug=True)
         tty.msg("\ntargets", debug=True)
-        if self.targets:
-            tty.msg(self.targets, debug=True)
-        else:
-            tty.msg([None], debug=True)
+        tty.msg("(streaming)", debug=True)
 
     @abstractmethod
     def launch(self):
@@ -66,6 +63,7 @@ class Frontend(ABC):
 
 class Cli(Frontend):
     success_count: int
+    total_count: int
 
     def __init__(self, settings: SettingStore):
         super().__init__(settings)
@@ -73,86 +71,82 @@ class Cli(Frontend):
             tty.error(USAGE)
             raise SystemExit(2)
         self.success_count = 0
-
-    @property
-    def total_count(self):
-        return len(self.targets)
+        self.total_count = 0
 
     @override
     def launch(self) -> None:
         tty.msg("Starting mnamer", MessageType.HEADING)
-        self._ensure_targets()
-        self._process_targets()
-        self._report_results()
-
-    def _ensure_targets(self) -> None:
-        if not self.targets:
+        found_any = False
+        for target in Target.iter_paths(self.settings):
+            found_any = True
+            self.total_count += 1
+            self.targets.append(target)
+            if not self._process_target(target):
+                break
+        if not found_any:
             tty.msg("", debug=True)
             tty.msg("no media files found", MessageType.ALERT)
             raise SystemExit(0)
+        self._report_results()
 
-    def _process_targets(self) -> None:
-        for target in self.targets:
-            self._announce_file(target)
-            self._list_details(target)
+    def _process_target(self, target: Target) -> bool:
+        """Process a single target. Returns False when the user aborts."""
+        self._announce_file(target)
+        self._list_details(target)
 
-            # find match for target
-            matches = []
-            try:
-                matches = target.query()
-            except MnamerNotFoundException:
-                tty.msg("no matches found", MessageType.ALERT)
-            except MnamerNetworkException:
-                tty.msg("network error", MessageType.ALERT)
-            if not matches and self.settings.no_guess:
-                tty.msg("skipping (--no-guess)", MessageType.ALERT)
-                continue
-            try:
-                if self.settings.batch:
-                    match = matches[0] if matches else target.metadata
-                elif not matches:
-                    match = tty.metadata_guess(target.metadata)
-                else:
-                    match = tty.metadata_prompt(matches)
-            except MnamerSkipException:
-                tty.msg("skipping (user request)", MessageType.ALERT)
-                continue
-            except MnamerAbortException:
-                tty.msg("aborting (user request)", MessageType.ERROR)
-                break
-            target.metadata.update(match)
+        matches = []
+        try:
+            matches = target.query()
+        except MnamerNotFoundException:
+            tty.msg("no matches found", MessageType.ALERT)
+        except MnamerNetworkException:
+            tty.msg("network error", MessageType.ALERT)
+        if not matches and self.settings.no_guess:
+            tty.msg("skipping (--no-guess)", MessageType.ALERT)
+            return True
+        try:
+            if self.settings.batch:
+                match = matches[0] if matches else target.metadata
+            elif not matches:
+                match = tty.metadata_guess(target.metadata, target)
+            else:
+                match = tty.metadata_prompt(matches, target)
+        except MnamerSkipException:
+            tty.msg("skipping (user request)", MessageType.ALERT)
+            return True
+        except MnamerAbortException:
+            tty.msg("aborting (user request)", MessageType.ERROR)
+            return False
+        target.metadata.update(match)
 
-            if (
-                is_subtitle(target.metadata.container)
-                and not target.metadata.language_sub
-            ):
-                if self.settings.batch:
-                    tty.msg(
-                        "skipping (subtitle language can't be detected)",
-                        MessageType.ALERT,
-                    )
-                    continue
-                try:
-                    target.metadata.language_sub = tty.subtitle_prompt()
-                except MnamerSkipException:
-                    tty.msg("skipping (user request)", MessageType.ALERT)
-                    continue
-                except MnamerAbortException:
-                    tty.msg("aborting (user request)", MessageType.ERROR)
-                    break
-
-            # sanity check move
-            if target.destination == target.source:
+        if is_subtitle(target.metadata.container) and not target.metadata.language_sub:
+            if self.settings.batch:
                 tty.msg(
-                    "skipping (source and destination paths are the same)",
+                    "skipping (subtitle language can't be detected)",
                     MessageType.ALERT,
                 )
-                continue
-            if self.settings.no_overwrite and target.destination.exists():
-                tty.msg("skipping (--no-overwrite)", MessageType.ALERT)
-                continue
+                return True
+            try:
+                target.metadata.language_sub = tty.subtitle_prompt()
+            except MnamerSkipException:
+                tty.msg("skipping (user request)", MessageType.ALERT)
+                return True
+            except MnamerAbortException:
+                tty.msg("aborting (user request)", MessageType.ERROR)
+                return False
 
-            self._rename_and_move_file(target)
+        if target.destination == target.source:
+            tty.msg(
+                "skipping (source and destination paths are the same)",
+                MessageType.ALERT,
+            )
+            return True
+        if self.settings.no_overwrite and target.destination.exists():
+            tty.msg("skipping (--no-overwrite)", MessageType.ALERT)
+            return True
+
+        self._rename_and_move_file(target)
+        return True
 
     def _announce_file(self, target: Target):
         media_type = target.metadata.to_media_type().value.title()

--- a/mnamer/frontends.py
+++ b/mnamer/frontends.py
@@ -6,10 +6,9 @@ from mnamer.const import SYSTEM, USAGE, VERSION
 from mnamer.exceptions import (
     MnamerAbortException,
     MnamerException,
-    MnamerNetworkException,
-    MnamerNotFoundException,
     MnamerSkipException,
 )
+from mnamer.prefetch import PreparedTarget, TargetLookahead
 from mnamer.setting_store import SettingStore
 from mnamer.target import Target
 from mnamer.types import MessageType
@@ -76,30 +75,30 @@ class Cli(Frontend):
     @override
     def launch(self) -> None:
         tty.msg("Starting mnamer", MessageType.HEADING)
-        found_any = False
-        for target in Target.iter_paths(self.settings):
-            found_any = True
-            self.total_count += 1
-            self.targets.append(target)
-            if not self._process_target(target):
-                break
-        if not found_any:
-            tty.msg("", debug=True)
-            tty.msg("no media files found", MessageType.ALERT)
-            raise SystemExit(0)
+        with TargetLookahead(Target.iter_paths(self.settings)) as lookahead:
+            prepared = lookahead.prime()
+            if prepared is None:
+                tty.msg("", debug=True)
+                tty.msg("no media files found", MessageType.ALERT)
+                raise SystemExit(0)
+            while prepared is not None:
+                self.total_count += 1
+                self.targets.append(prepared.target)
+                if not self._process_prepared(prepared):
+                    break
+                prepared = lookahead.take()
         self._report_results()
 
-    def _process_target(self, target: Target) -> bool:
-        """Process a single target. Returns False when the user aborts."""
+    def _process_prepared(self, prepared: PreparedTarget) -> bool:
+        """Process a prepared target. Returns False when the user aborts."""
+        target = prepared.target
         self._announce_file(target)
         self._list_details(target)
 
-        matches = []
-        try:
-            matches = target.query()
-        except MnamerNotFoundException:
+        matches = prepared.matches
+        if prepared.not_found:
             tty.msg("no matches found", MessageType.ALERT)
-        except MnamerNetworkException:
+        elif prepared.network_error:
             tty.msg("network error", MessageType.ALERT)
         if not matches and self.settings.no_guess:
             tty.msg("skipping (--no-guess)", MessageType.ALERT)

--- a/mnamer/frontends.py
+++ b/mnamer/frontends.py
@@ -103,6 +103,16 @@ class Cli(Frontend):
         if not matches and self.settings.no_guess:
             tty.msg("skipping (--no-guess)", MessageType.ALERT)
             return True
+        if (
+            self.settings.skip_correct
+            and matches
+            and target.preview_filename(matches[0]) == target.source.name
+        ):
+            tty.msg(
+                "skipping (--skip-correct, already matches top hit)",
+                MessageType.ALERT,
+            )
+            return True
         try:
             if self.settings.batch:
                 match = matches[0] if matches else target.metadata

--- a/mnamer/media_info.py
+++ b/mnamer/media_info.py
@@ -1,0 +1,97 @@
+"""Inspect local media files for technical metadata."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def resolution_label(width: int | None, height: int | None) -> str | None:
+    """
+    Map pixel dimensions to a common label like 1080p.
+
+    Uses width-or-height thresholds so cropped widescreen encodes (e.g. 1920x800)
+    still count as 1080p.
+    """
+    w = width or 0
+    h = height or 0
+    if w <= 0 and h <= 0:
+        return None
+    if w >= 3800 or h >= 2100:
+        return "2160p"
+    if w >= 2500 or h >= 1400:
+        return "1440p"
+    if w >= 1900 or h >= 1000:
+        return "1080p"
+    if w >= 1200 or h >= 700:
+        return "720p"
+    if w >= 1000 or h >= 560:
+        return "576p"
+    if w >= 700 or h >= 460:
+        return "480p"
+    if h > 0:
+        return f"{h}p"
+    return f"{w}p"
+
+
+def probe_resolution(path: Path | str) -> str | None:
+    """
+    Detect video resolution from the file via ffprobe.
+
+    Returns None when ffprobe is unavailable, the path is missing, or probing fails.
+    """
+    file_path = Path(path)
+    if not file_path.is_file():
+        return None
+    ffprobe = shutil.which("ffprobe")
+    if not ffprobe:
+        return None
+    try:
+        completed = subprocess.run(
+            [
+                ffprobe,
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=width,height",
+                "-of",
+                "json",
+                str(file_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0 or not completed.stdout.strip():
+        return None
+    try:
+        payload = json.loads(completed.stdout)
+        stream = (payload.get("streams") or [{}])[0]
+        width = int(stream["width"]) if stream.get("width") else None
+        height = int(stream["height"]) if stream.get("height") else None
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+    return resolution_label(width, height)
+
+
+def normalize_resolution_token(value: str | None) -> str | None:
+    """Normalize guessit screen_size values into the same labels as probing."""
+    if not value:
+        return None
+    text = str(value).strip().lower()
+    if not text:
+        return None
+    if text in {"4k", "uhd", "2160p"}:
+        return "2160p"
+    match = re.fullmatch(r"(\d{3,4})p", text)
+    if match:
+        return resolution_label(None, int(match.group(1)))
+    return text

--- a/mnamer/media_info.py
+++ b/mnamer/media_info.py
@@ -8,6 +8,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+PROBE_TIMEOUT_SECONDS = 5
+
 
 def resolution_label(width: int | None, height: int | None) -> str | None:
     """
@@ -41,11 +43,9 @@ def probe_resolution(path: Path | str) -> str | None:
     """
     Detect video resolution from the file via ffprobe.
 
-    Returns None when ffprobe is unavailable, the path is missing, or probing fails.
+    Assumes ``path`` already refers to a media file discovered by the crawler.
+    Returns None when ffprobe is unavailable or probing fails.
     """
-    file_path = Path(path)
-    if not file_path.is_file():
-        return None
     ffprobe = shutil.which("ffprobe")
     if not ffprobe:
         return None
@@ -61,11 +61,11 @@ def probe_resolution(path: Path | str) -> str | None:
                 "stream=width,height",
                 "-of",
                 "json",
-                str(file_path),
+                str(path),
             ],
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=PROBE_TIMEOUT_SECONDS,
             check=False,
         )
     except (OSError, subprocess.TimeoutExpired):

--- a/mnamer/metadata.py
+++ b/mnamer/metadata.py
@@ -46,6 +46,7 @@ class Metadata:
     language: Language | None = None
     language_sub: Language | None = None
     quality: str | None = None
+    resolution: str | None = None
     synopsis: str | None = None
 
     @classmethod
@@ -66,6 +67,7 @@ class Metadata:
             "language_sub": Language.parse,
             "media": MediaType,
             "quality": str.lower,
+            "resolution": str.lower,
             "synopsis": str.capitalize,
         }
         converter: Callable[[Any], Any] | None = converter_map.get(key)

--- a/mnamer/prefetch.py
+++ b/mnamer/prefetch.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
-from typing import Iterator
 
 from mnamer.exceptions import MnamerNetworkException, MnamerNotFoundException
 from mnamer.metadata import Metadata

--- a/mnamer/prefetch.py
+++ b/mnamer/prefetch.py
@@ -1,0 +1,95 @@
+"""Background preparation of the next media target while the user chooses."""
+
+from __future__ import annotations
+
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import Iterator
+
+from mnamer.exceptions import MnamerNetworkException, MnamerNotFoundException
+from mnamer.metadata import Metadata
+from mnamer.target import Target
+
+
+@dataclass
+class PreparedTarget:
+    """A discovered target with its provider query already attempted."""
+
+    target: Target
+    matches: list[Metadata] = field(default_factory=list)
+    not_found: bool = False
+    network_error: bool = False
+
+
+def prepare_target(target: Target) -> PreparedTarget:
+    """Run provider query (and optional resolution probe) for a target."""
+    prepared = PreparedTarget(target=target)
+    try:
+        prepared.matches = target.query()
+    except MnamerNotFoundException:
+        prepared.not_found = True
+        prepared.matches = []
+    except MnamerNetworkException:
+        prepared.network_error = True
+        prepared.matches = []
+    if target.needs_resolution():
+        target.ensure_resolution()
+    return prepared
+
+
+def _discover_and_prepare(targets: Iterator[Target]) -> PreparedTarget | None:
+    try:
+        target = next(targets)
+    except StopIteration:
+        return None
+    return prepare_target(target)
+
+
+class TargetLookahead:
+    """
+    One-file lookahead: while the user is prompted for the current file,
+    discover and query the next one on a background thread.
+    """
+
+    def __init__(self, targets: Iterator[Target]):
+        self._targets = targets
+        self._executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="mnamer-prefetch"
+        )
+        self._future: Future[PreparedTarget | None] | None = None
+
+    def __enter__(self) -> TargetLookahead:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if self._future is not None:
+            # Don't cancel mid-request; just wait so the session stays consistent.
+            try:
+                self._future.result()
+            except Exception:
+                pass
+            self._future = None
+        self._executor.shutdown(wait=True)
+
+    def prime(self) -> PreparedTarget | None:
+        """Synchronously prepare the first target, then start prefetching the next."""
+        prepared = _discover_and_prepare(self._targets)
+        if prepared is not None:
+            self._schedule_prefetch()
+        return prepared
+
+    def take(self) -> PreparedTarget | None:
+        """Return the next prepared target, waiting for prefetch if needed."""
+        if self._future is None:
+            return _discover_and_prepare(self._targets)
+        prepared = self._future.result()
+        self._future = None
+        if prepared is not None:
+            self._schedule_prefetch()
+        return prepared
+
+    def _schedule_prefetch(self) -> None:
+        self._future = self._executor.submit(_discover_and_prepare, self._targets)

--- a/mnamer/providers.py
+++ b/mnamer/providers.py
@@ -39,12 +39,14 @@ class Provider[M: Metadata](ABC):
 
     api_key: str
     cache: bool = True
+    hits: int = 5
 
-    def __init__(self, api_key: str = "", cache: bool = True):
+    def __init__(self, api_key: str = "", cache: bool = True, hits: int = 5):
         """Initializes the provider."""
         if api_key:
             self.api_key = api_key
         self.cache = cache
+        self.hits = hits
 
     @classmethod
     def from_settings(cls, settings: SettingStore) -> Self:
@@ -52,7 +54,7 @@ class Provider[M: Metadata](ABC):
         api_field = f"api_key_{cls.__name__.lower()}"
         api_key = getattr(settings, api_field)
         cache = not settings.no_cache
-        return cls(api_key, cache)
+        return cls(api_key, cache, settings.hits)
 
     @abstractmethod
     def search(self, query: M) -> Iterator[M]:
@@ -104,8 +106,8 @@ class Omdb(Provider[MetadataMovie]):
 
     api_key: str = environ.get("API_KEY_OMDB", "477a7ebc")
 
-    def __init__(self, api_key: str = "", cache: bool = True):
-        super().__init__(api_key, cache)
+    def __init__(self, api_key: str = "", cache: bool = True, hits: int = 5):
+        super().__init__(api_key, cache, hits)
         assert self.api_key
 
     @override
@@ -177,8 +179,8 @@ class Tmdb(Provider[MetadataMovie]):
 
     api_key: str = environ.get("API_KEY_TMDB", "db972a607f2760bb19ff8bb34074b4c7")
 
-    def __init__(self, api_key: str = "", cache: bool = True):
-        super().__init__(api_key, cache)
+    def __init__(self, api_key: str = "", cache: bool = True, hits: int = 5):
+        super().__init__(api_key, cache, hits)
         assert self.api_key
 
     @override
@@ -256,8 +258,8 @@ class Tvdb(Provider[MetadataEpisode]):
     api_key: str = environ.get("API_KEY_TVDB", "E69C7A2CEF2F3152")
     token: str
 
-    def __init__(self, api_key: str = "", cache: bool = True):
-        super().__init__(api_key, cache)
+    def __init__(self, api_key: str = "", cache: bool = True, hits: int = 5):
+        super().__init__(api_key, cache, hits)
         assert self.api_key
         self.token = "" if self.cache else self._login()
 
@@ -344,7 +346,9 @@ class Tvdb(Provider[MetadataEpisode]):
             self.token, series, language=language, cache=self.cache
         )
 
-        for series_id in [str(entry["id"]) for entry in series_data["data"][:5]]:
+        for series_id in [
+            str(entry["id"]) for entry in series_data["data"][: self.hits]
+        ]:
             try:
                 for data in self._search_id(series_id, season, episode, language):
                     if not data.series or not data.season:
@@ -375,7 +379,7 @@ class Tvdb(Provider[MetadataEpisode]):
         series_data = tvdb_search_series(
             self.token, series, language=language, cache=self.cache
         )
-        tvdb_ids = [str(entry["id"]) for entry in series_data["data"][:5]]
+        tvdb_ids = [str(entry["id"]) for entry in series_data["data"][: self.hits]]
         found = False
         for tvdb_id in tvdb_ids:
             try:
@@ -478,7 +482,7 @@ class TvMaze(Provider[MetadataEpisode]):
         assert season
         series_data = tvmaze_show_search(series)
         for idx, search_entry in enumerate(series_data):
-            if idx >= 3:
+            if idx >= self.hits:
                 break
             series_entry = search_entry["show"]
             id_tvmaze = str(series_entry["id"])
@@ -499,7 +503,7 @@ class TvMaze(Provider[MetadataEpisode]):
         assert series
         series_data = tvmaze_show_search(series)
         for idx, search_entry in enumerate(series_data):
-            if idx >= 3:
+            if idx >= self.hits:
                 break
             series_entry = search_entry["show"]
             id_tvmaze = str(series_entry["id"])

--- a/mnamer/setting_store.py
+++ b/mnamer/setting_store.py
@@ -180,7 +180,7 @@ class SettingStore:
         ).as_dict(),
     )
     movie_format: str = dataclasses.field(
-        default="{name} ({year}).{extension}",
+        default="{name} ({year}) [{resolution}].{extension}",
         metadata=SettingSpec(
             dest="movie_format",
             flags=["--movie_format", "--movie-format", "--movieformat"],

--- a/mnamer/setting_store.py
+++ b/mnamer/setting_store.py
@@ -146,6 +146,19 @@ class SettingStore:
             help="--no-overwrite: prevent relocation if it would overwrite a file",
         ).as_dict(),
     )
+    skip_correct: bool = dataclasses.field(
+        default=False,
+        metadata=SettingSpec(
+            action="store_true",
+            dest="skip_correct",
+            flags=["--skip_correct", "--skip-correct", "--skipcorrect"],
+            group=SettingType.PARAMETER,
+            help=(
+                "--skip-correct: skip when the current filename already matches "
+                "the top hit"
+            ),
+        ).as_dict(),
+    )
     no_style: bool = dataclasses.field(
         default=False,
         metadata=SettingSpec(

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -358,6 +358,7 @@ class Target:
         except MnamerException:
             pass
         return Path(self.source.parent, stem)
+
     @staticmethod
     def _movie_name_and_year(
         filename: str, title: str | None, guessed_year: int | str | None

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -61,14 +61,38 @@ class Target:
         return str(self.source.resolve())
 
     @classmethod
-    def iter_paths(cls, settings: SettingStore) -> Iterator[Self]:
+    def destination_skip_dirs(cls, settings: SettingStore) -> list[Path]:
+        """Concrete relocation roots that should not be crawled for new inputs."""
+        skip_dirs: list[Path] = []
+        for attr in ("movie_directory", "episode_directory"):
+            directory = getattr(settings, attr)
+            if directory is None:
+                continue
+            # Templated destinations (e.g. Movies/{name}) can't be pruned upfront.
+            if "{" in str(directory):
+                continue
+            skip_dirs.append(Path(directory))
+        return skip_dirs
+
+    @classmethod
+    def iter_paths(
+        cls,
+        settings: SettingStore,
+        exclude_paths: set[Path] | None = None,
+    ) -> Iterator[Self]:
         """Yields Target objects as matching media files are discovered."""
-        file_paths = crawl_in(settings.targets, settings.recurse)
+        exclude_paths = exclude_paths if exclude_paths is not None else set()
+        file_paths = crawl_in(
+            settings.targets,
+            settings.recurse,
+            exclude_paths=exclude_paths,
+            skip_dirs=cls.destination_skip_dirs(settings),
+        )
         file_paths = filter_blacklist(file_paths, settings.ignore)
         file_paths = filter_containers(file_paths, settings.mask)
         seen: set[Path] = set()
         for file_path in file_paths:
-            if file_path in seen:
+            if file_path in seen or file_path in exclude_paths:
                 continue
             seen.add(file_path)
             target = cls(file_path, settings)

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import re
 from pathlib import Path
 from shutil import move
 from typing import Any, ClassVar, Self, override
@@ -22,6 +23,7 @@ from mnamer.utils import (
     str_replace,
     str_sanitize,
     str_scenify,
+    year_from_brackets,
 )
 
 
@@ -215,8 +217,9 @@ class Target:
         except MnamerException:
             pass
         if isinstance(self.metadata, MetadataMovie):
-            self.metadata.name = path_data.get("title")
-            self.metadata.year = path_data.get("year")
+            self.metadata.name, self.metadata.year = self._movie_name_and_year(
+                file_path.name, path_data.get("title"), path_data.get("year")
+            )
         elif isinstance(self.metadata, MetadataEpisode):
             self.metadata.date = path_data.get("date")
             self.metadata.episode = path_data.get("episode")
@@ -229,6 +232,29 @@ class Target:
             # year = path_data.get("year")
             # if year:
             #     self.metadata.series = f"{self.metadata.series} {year}"
+
+    @staticmethod
+    def _movie_name_and_year(
+        filename: str, title: str | None, guessed_year: int | str | None
+    ) -> tuple[str | None, int | None]:
+        """
+        Only treat a number as the release year when it appears in () or [].
+        Bare years (e.g. leading 2001 in "2001 A Space Odyssey") stay in the title.
+        """
+        bracket_year = year_from_brackets(filename)
+        if bracket_year is not None:
+            return title, bracket_year
+        if guessed_year is None:
+            return title, None
+        year_str = str(guessed_year)
+        if title and year_str not in title:
+            # Prefer original token order from the filename stem.
+            stem = Path(filename).stem.replace(".", " ")
+            if re.search(rf"(?i)^\s*{year_str}\b", stem):
+                title = f"{year_str} {title}"
+            else:
+                title = f"{title} {year_str}"
+        return title, None
 
     def _override_metadata_ids(self):
         id_types = {"imdb", "tmdb", "tvdb", "tvmaze"}
@@ -267,12 +293,12 @@ class Target:
             return []
         seen = set()
         response = []
-        for idx, result in enumerate(results, start=1):
+        for result in results:
             if str(result) in seen:
                 continue
             response.append(result)
             seen.add(str(result))
-            if idx >= self._settings.hits:
+            if len(response) >= self._settings.hits:
                 break
         return response
 

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -225,16 +225,15 @@ class Target:
 
     def _parse(self, file_path: Path):
         path_data: dict[str, Any] = {"language": self._settings.language}
+        container = file_path.suffix or None
+        guess_path = file_path
         if is_subtitle(self.source):
-            try:
-                path_data["language"] = Language.parse(self.source.stem[-2:])
-                file_path = Path(self.source.parent, self.source.stem[:-2])
-            except MnamerException:
-                pass
+            container = self.source.suffix
+            guess_path = self._subtitle_guess_path(path_data)
         options = {"type": self._settings.media, "language": path_data["language"]}
-        raw_data = dict(guessit(str(file_path), options))
+        raw_data = dict(guessit(str(guess_path), options))
         if isinstance(raw_data.get("season"), list):
-            raw_data = dict(guessit(str(file_path.parts[-1]), options))
+            raw_data = dict(guessit(str(guess_path.parts[-1]), options))
         for k, v in raw_data.items():
             if hasattr(v, "alpha3"):
                 try:
@@ -281,7 +280,7 @@ class Target:
             path_data["language"] = self._settings.language
         self.metadata.language = path_data.get("language")
         self.metadata.group = path_data.get("release_group")
-        self.metadata.container = file_path.suffix or None
+        self.metadata.container = container
         if not self.metadata.language:
             try:
                 self.metadata.language = path_data.get("language")
@@ -293,7 +292,7 @@ class Target:
             pass
         if isinstance(self.metadata, MetadataMovie):
             self.metadata.name, self.metadata.year = self._movie_name_and_year(
-                file_path.name, path_data.get("title"), path_data.get("year")
+                guess_path.name, path_data.get("title"), path_data.get("year")
             )
         elif isinstance(self.metadata, MetadataEpisode):
             self.metadata.date = path_data.get("date")
@@ -304,6 +303,30 @@ class Target:
             if alternative_title:
                 self.metadata.series = f"{self.metadata.series} {alternative_title}"
 
+    def _subtitle_guess_path(self, path_data: dict[str, Any]) -> Path:
+        """
+        Strip subtitle container and optional language code for title guessing.
+
+        ``Movie.en.srt`` → guess against ``Movie`` and set ``subtitle_language``.
+        ``Eng.srt`` → language from the whole stem; guess against the parent folder.
+        """
+        stem = self.source.stem
+        if "." in stem:
+            base, maybe_lang = stem.rsplit(".", 1)
+            try:
+                path_data["subtitle_language"] = Language.parse(maybe_lang)
+                return Path(self.source.parent, base)
+            except MnamerException:
+                return Path(self.source.parent, stem)
+        try:
+            path_data["subtitle_language"] = Language.parse(stem)
+            # Common layout: ``Movie Name (2001)/Eng.srt``
+            parent = self.source.parent
+            if parent.name:
+                return parent
+        except MnamerException:
+            pass
+        return Path(self.source.parent, stem)
     @staticmethod
     def _movie_name_and_year(
         filename: str, title: str | None, guessed_year: int | str | None

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -230,7 +230,14 @@ class Target:
         if is_subtitle(self.source):
             container = self.source.suffix
             guess_path = self._subtitle_guess_path(path_data)
-        options = {"type": self._settings.media, "language": path_data["language"]}
+        # guessit expects type as a string ('movie'/'episode'); passing the
+        # MediaType enum makes it ignore the hint and mis-parse titles like
+        # "The 400 Blows" (400 → season/episode, title → "The").
+        media_hint = self._settings.media
+        options = {
+            "type": media_hint.value if media_hint else None,
+            "language": path_data["language"],
+        }
         raw_data = dict(guessit(str(guess_path), options))
         if isinstance(raw_data.get("season"), list):
             raw_data = dict(guessit(str(guess_path.parts[-1]), options))

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -362,14 +362,14 @@ class Target:
     @staticmethod
     def _movie_name_and_year(
         filename: str, title: str | None, guessed_year: int | str | None
-    ) -> tuple[str | None, int | None]:
+    ) -> tuple[str | None, str | None]:
         """
         Only treat a number as the release year when it appears in () or [].
         Bare years (e.g. leading 2001 in "2001 A Space Odyssey") stay in the title.
         """
         bracket_year = year_from_brackets(filename)
         if bracket_year is not None:
-            return title, bracket_year
+            return title, str(bracket_year)
         if guessed_year is None:
             return title, None
         year_str = str(guessed_year)

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 import re
+from collections.abc import Iterator
 from pathlib import Path
 from shutil import move
 from typing import Any, ClassVar, Self, override
@@ -37,6 +38,7 @@ class Target:
     _provider: Provider[Any]
     _has_moved: bool
     _has_renamed: bool
+    _resolution_probed: bool
 
     source: Path
     metadata: Metadata
@@ -46,6 +48,7 @@ class Target:
         self._settings = settings or SettingStore()
         self._has_moved = False
         self._has_renamed = False
+        self._resolution_probed = False
         self._parse(file_path)
         self._replace_before()
         self._override_metadata_ids()
@@ -56,15 +59,24 @@ class Target:
         return str(self.source.resolve())
 
     @classmethod
-    def populate_paths(cls, settings: SettingStore) -> list[Self]:
-        """Creates a list of Target objects for media files found in paths."""
+    def iter_paths(cls, settings: SettingStore) -> Iterator[Self]:
+        """Yields Target objects as matching media files are discovered."""
         file_paths = crawl_in(settings.targets, settings.recurse)
         file_paths = filter_blacklist(file_paths, settings.ignore)
         file_paths = filter_containers(file_paths, settings.mask)
-        targets = [cls(file_path, settings) for file_path in file_paths]
-        targets = list(dict.fromkeys(targets))  # unique values
-        targets = list(filter(cls._matches_media, targets))
-        return targets
+        seen: set[Path] = set()
+        for file_path in file_paths:
+            if file_path in seen:
+                continue
+            seen.add(file_path)
+            target = cls(file_path, settings)
+            if cls._matches_media(target):
+                yield target
+
+    @classmethod
+    def populate_paths(cls, settings: SettingStore) -> list[Self]:
+        """Creates a list of Target objects for media files found in paths."""
+        return list(cls.iter_paths(settings))
 
     @classmethod
     def reset_providers(cls):
@@ -89,12 +101,68 @@ class Target:
         directory = getattr(self._settings, settings_key)
         return Path(directory) if directory else None
 
+    def needs_resolution(self, metadata: Metadata | None = None) -> bool:
+        """True when a configured format/directory template uses {resolution}."""
+        metadata = metadata or self.metadata
+        format_spec = self._settings.formatting_for(metadata)
+        directory = getattr(
+            self._settings, f"{metadata.to_media_type().value}_directory", None
+        )
+        return "{resolution}" in format_spec or (
+            directory is not None and "{resolution}" in str(directory)
+        )
+
+    def ensure_resolution(self) -> None:
+        """
+        Resolve ``metadata.resolution`` when needed for formatting.
+
+        Prefers a filename-derived screen size. Only probes the file (ffprobe)
+        when resolution is still unknown and a template requires it.
+        """
+        if self.metadata.resolution is not None or self._resolution_probed:
+            return
+        if not self.needs_resolution():
+            return
+        self._resolution_probed = True
+        self.metadata.resolution = probe_resolution(self.source)
+
     @property
     def destination(self) -> Path:
         """
         The destination Path for the target based on its metadata and user
         preferences.
         """
+        self.ensure_resolution()
+        return self._build_destination()
+
+    def destination_for(self, match: Metadata) -> Path:
+        """Destination path as if ``match`` were applied on top of this target."""
+        if match is self.metadata:
+            return self.destination
+        changed: dict[str, Any] = {}
+        for field in vars(self.metadata):
+            if field.startswith("_"):
+                continue
+            new_value = getattr(match, field, None)
+            if new_value is None:
+                continue
+            old_value = getattr(self.metadata, field)
+            if old_value == new_value:
+                continue
+            changed[field] = old_value
+            setattr(self.metadata, field, new_value)
+        try:
+            self.ensure_resolution()
+            return self._build_destination()
+        finally:
+            for field, old_value in changed.items():
+                object.__setattr__(self.metadata, field, old_value)
+
+    def preview_filename(self, match: Metadata) -> str:
+        """Filename that would result from selecting ``match``."""
+        return self.destination_for(match).name
+
+    def _build_destination(self) -> Path:
         if self.directory:
             dir_head = self._format_directory(self.directory)
         else:
@@ -203,8 +271,9 @@ class Target:
             )
             or None
         )
-        self.metadata.resolution = probe_resolution(file_path) or (
-            normalize_resolution_token(path_data.get("screen_size"))
+        # Filename-derived resolution only; file probing is deferred until needed.
+        self.metadata.resolution = normalize_resolution_token(
+            path_data.get("screen_size")
         )
         if self._settings.language:
             path_data["language"] = self._settings.language
@@ -232,10 +301,6 @@ class Target:
             alternative_title = path_data.get("alternative_title")
             if alternative_title:
                 self.metadata.series = f"{self.metadata.series} {alternative_title}"
-            # adding year to title can reduce false positives
-            # year = path_data.get("year")
-            # if year:
-            #     self.metadata.series = f"{self.metadata.series} {year}"
 
     @staticmethod
     def _movie_name_and_year(

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 import re
+import threading
 from collections.abc import Iterator
 from pathlib import Path
 from shutil import move
@@ -33,6 +34,7 @@ class Target:
     """Manages metadata state for a media file and facilitates its relocation."""
 
     _providers: ClassVar[dict[ProviderType, Provider[Any]]] = {}
+    _provider_lock: ClassVar[threading.Lock] = threading.Lock()
 
     _settings: SettingStore
     _provider: Provider[Any]
@@ -338,11 +340,12 @@ class Target:
 
     def _register_provider(self) -> None:
         provider_type = self.provider_type
-        if provider_type and provider_type not in self._providers:
-            self._providers[provider_type] = Provider.provider_factory(
-                provider_type, self._settings
-            )
-        self._provider = self._providers[provider_type]
+        with self._provider_lock:
+            if provider_type and provider_type not in self._providers:
+                self._providers[provider_type] = Provider.provider_factory(
+                    provider_type, self._settings
+                )
+            self._provider = self._providers[provider_type]
 
     def _replace_before(self) -> None:
         if not self._settings.replace_before:

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -10,6 +10,7 @@ from guessit import guessit  # type: ignore
 
 from mnamer.exceptions import MnamerException
 from mnamer.language import Language
+from mnamer.media_info import normalize_resolution_token, probe_resolution
 from mnamer.metadata import Metadata, MetadataEpisode, MetadataMovie
 from mnamer.providers import Provider
 from mnamer.setting_store import SettingStore
@@ -201,6 +202,9 @@ class Target:
                 )
             )
             or None
+        )
+        self.metadata.resolution = probe_resolution(file_path) or (
+            normalize_resolution_token(path_data.get("screen_size"))
         )
         if self._settings.language:
             path_data["language"] = self._settings.language

--- a/mnamer/tty.py
+++ b/mnamer/tty.py
@@ -1,5 +1,8 @@
 """Provides an interface for handling user input and printing output."""
 
+from __future__ import annotations
+
+import re
 import traceback
 from collections.abc import Callable
 from typing import Any
@@ -9,16 +12,26 @@ from teletype.components import ChoiceHelper, SelectOne
 from teletype.io import style_format, style_print
 
 from mnamer.const import SYSTEM
-from mnamer.exceptions import MnamerAbortException, MnamerException, MnamerSkipException
+from mnamer.exceptions import (
+    MnamerAbortException,
+    MnamerException,
+    MnamerNetworkException,
+    MnamerNotFoundException,
+    MnamerSkipException,
+)
 from mnamer.language import Language
-from mnamer.metadata import Metadata
+from mnamer.metadata import Metadata, MetadataEpisode, MetadataMovie
 from mnamer.setting_store import SettingStore
 from mnamer.target import Target
 from mnamer.types import MessageType
-from mnamer.utils import format_dict, format_exception, format_iter
+from mnamer.utils import format_dict, format_exception, format_iter, year_from_brackets
 
 no_style: bool = False
 verbose: bool = False
+
+
+class EditSearchAction:
+    """Sentinel chosen when the user wants to edit the provider search string."""
 
 
 def _chars() -> dict[str, str]:
@@ -47,6 +60,12 @@ def _abort_helpers() -> tuple[
     )
 
 
+def _edit_search_helper() -> ChoiceHelper[EditSearchAction]:
+    if no_style:
+        return ChoiceHelper(EditSearchAction(), "edit search", None, "[e]")
+    return ChoiceHelper(EditSearchAction(), "edit search", "dark", "e")
+
+
 def _msg_format(body: Any) -> str:
     converter_map: dict[type, Callable[[Any], str]] = {
         dict: format_dict,
@@ -73,6 +92,77 @@ def _match_choice_helpers(
     return choices
 
 
+def search_string_for(metadata: Metadata) -> str:
+    """Return the provider search text currently used for this metadata."""
+    if isinstance(metadata, MetadataMovie):
+        return metadata.name or ""
+    if isinstance(metadata, MetadataEpisode):
+        return metadata.series or ""
+    return ""
+
+
+def apply_search_string(metadata: Metadata, text: str) -> None:
+    """Apply an edited search string and clear IDs so providers search by name."""
+    year = year_from_brackets(text)
+    if year is not None:
+        text = re.sub(r"\s*[\(\[](?:19|20)\d{2}[\)\]]\s*", " ", text).strip()
+    text = re.sub(r"\s+", " ", text).strip()
+    if isinstance(metadata, MetadataMovie):
+        metadata.id_tmdb = None
+        metadata.id_imdb = None
+        metadata.name = text or None
+        metadata.year = year
+    elif isinstance(metadata, MetadataEpisode):
+        metadata.id_tvdb = None
+        metadata.id_tvmaze = None
+        metadata.series = text or None
+
+
+def prompt_with_prefill(prompt: str, default: str) -> str:
+    """
+    Read a line of input with ``default`` inserted for editing when possible.
+
+    Uses readline's pre-input hook when available; otherwise shows the default
+    in brackets and keeps it when the user submits an empty line.
+    """
+    try:
+        import readline
+    except ImportError:  # pragma: no cover - Windows without pyreadline
+        value = input(f"{prompt}[{default}] ")
+        return default if value == "" else value
+
+    def _hook() -> None:
+        readline.insert_text(default)
+        readline.redisplay()
+
+    readline.set_pre_input_hook(_hook)
+    try:
+        return input(prompt)
+    finally:
+        readline.set_pre_input_hook()
+
+
+def _prompt_search_string(default: str) -> str | None:
+    msg("edit search string")
+    try:
+        value = prompt_with_prefill("search: ", default)
+    except (EOFError, KeyboardInterrupt) as e:
+        raise MnamerSkipException from e
+    value = value.strip()
+    return value or None
+
+
+def _requery(target: Target) -> list[Metadata]:
+    try:
+        return target.query()
+    except MnamerNotFoundException:
+        msg("no matches found", MessageType.ALERT)
+        return []
+    except MnamerNetworkException:
+        msg("network error", MessageType.ALERT)
+        return []
+
+
 def configure(settings: SettingStore):
     """Sets class variables using a settings instance."""
     global verbose, no_style
@@ -97,32 +187,54 @@ def error(body: Any):
     msg(body, message_type=MessageType.ERROR, debug=False)
 
 
-def metadata_prompt(matches: list[Metadata], target: Target) -> Metadata:  # pragma: no cover
-    """Prompts user to choose a match from a list of matches."""
-    msg("select match")
-    choices = [*_match_choice_helpers(matches, target), *_abort_helpers()]
-    selector = SelectOne(choices, **_chars())
-    choice = selector.prompt()
-    if isinstance(choice, MnamerAbortException | MnamerSkipException):
-        raise choice
-    return choice
+def metadata_prompt(  # pragma: no cover
+    matches: list[Metadata], target: Target
+) -> Metadata:
+    """
+    Prompt the user to choose a match, optionally editing the search string.
 
-
-def metadata_guess(metadata: Metadata, target: Target) -> Metadata:  # pragma: no cover
-    """Prompts user to confirm a single match."""
-    preview = target.preview_filename(metadata)
-    label = f"{metadata}  {preview}"
-    if no_style:
-        label += " (best guess)"
-    else:
-        label += style_format(" (best guess)", "blue")
-    option = ChoiceHelper(metadata, label)
-    selector = SelectOne([option, *_abort_helpers()], **_chars())
-    choice = selector.prompt()
-    if isinstance(choice, MnamerAbortException | MnamerSkipException):
-        raise choice
-    else:
+    Selecting "edit search" re-queries the provider and shows results again.
+    """
+    while True:
+        if matches:
+            msg("select match")
+            choices: list[Any] = [
+                *_match_choice_helpers(matches, target),
+                _edit_search_helper(),
+                *_abort_helpers(),
+            ]
+        else:
+            label = str(target.metadata)
+            if no_style:
+                label += " (best guess)"
+            else:
+                label += style_format(" (best guess)", "blue")
+            choices = [
+                ChoiceHelper(target.metadata, label),
+                _edit_search_helper(),
+                *_abort_helpers(),
+            ]
+            msg("select match")
+        selector = SelectOne(choices, **_chars())
+        choice = selector.prompt()
+        if isinstance(choice, EditSearchAction):
+            edited = _prompt_search_string(search_string_for(target.metadata))
+            if edited is None:
+                continue
+            apply_search_string(target.metadata, edited)
+            matches = _requery(target)
+            continue
+        if isinstance(choice, MnamerAbortException | MnamerSkipException):
+            raise choice
         return choice
+
+
+def metadata_guess(
+    metadata: Metadata, target: Target
+) -> Metadata:  # pragma: no cover
+    """Prompts user to confirm a single match (or edit the search string)."""
+    del metadata  # search context comes from target.metadata
+    return metadata_prompt([], target)
 
 
 def subtitle_prompt() -> Language:

--- a/mnamer/tty.py
+++ b/mnamer/tty.py
@@ -229,9 +229,7 @@ def metadata_prompt(  # pragma: no cover
         return choice
 
 
-def metadata_guess(
-    metadata: Metadata, target: Target
-) -> Metadata:  # pragma: no cover
+def metadata_guess(metadata: Metadata, target: Target) -> Metadata:  # pragma: no cover
     """Prompts user to confirm a single match (or edit the search string)."""
     del metadata  # search context comes from target.metadata
     return metadata_prompt([], target)

--- a/mnamer/tty.py
+++ b/mnamer/tty.py
@@ -13,6 +13,7 @@ from mnamer.exceptions import MnamerAbortException, MnamerException, MnamerSkipE
 from mnamer.language import Language
 from mnamer.metadata import Metadata
 from mnamer.setting_store import SettingStore
+from mnamer.target import Target
 from mnamer.types import MessageType
 from mnamer.utils import format_dict, format_exception, format_iter
 
@@ -58,6 +59,20 @@ def _msg_format(body: Any) -> str:
     return converter(body)
 
 
+def _match_choice_helpers(
+    matches: list[Metadata], target: Target
+) -> list[ChoiceHelper[Metadata]]:
+    """Build two-column choice labels: match title and destination filename."""
+    titles = [str(match) for match in matches]
+    width = max((len(title) for title in titles), default=0)
+    choices: list[ChoiceHelper[Metadata]] = []
+    for match, title in zip(matches, titles, strict=True):
+        preview = target.preview_filename(match)
+        label = f"{title.ljust(width)}  {preview}"
+        choices.append(ChoiceHelper(match, label))
+    return choices
+
+
 def configure(settings: SettingStore):
     """Sets class variables using a settings instance."""
     global verbose, no_style
@@ -82,19 +97,21 @@ def error(body: Any):
     msg(body, message_type=MessageType.ERROR, debug=False)
 
 
-def metadata_prompt(matches: list[Metadata]) -> Metadata:  # pragma: no cover
+def metadata_prompt(matches: list[Metadata], target: Target) -> Metadata:  # pragma: no cover
     """Prompts user to choose a match from a list of matches."""
     msg("select match")
-    selector = SelectOne([*matches, *_abort_helpers()], **_chars())
+    choices = [*_match_choice_helpers(matches, target), *_abort_helpers()]
+    selector = SelectOne(choices, **_chars())
     choice = selector.prompt()
     if isinstance(choice, MnamerAbortException | MnamerSkipException):
         raise choice
     return choice
 
 
-def metadata_guess(metadata: Metadata) -> Metadata:  # pragma: no cover
+def metadata_guess(metadata: Metadata, target: Target) -> Metadata:  # pragma: no cover
     """Prompts user to confirm a single match."""
-    label = str(metadata)
+    preview = target.preview_filename(metadata)
+    label = f"{metadata}  {preview}"
     if no_style:
         label += " (best guess)"
     else:

--- a/mnamer/tty.py
+++ b/mnamer/tty.py
@@ -111,7 +111,7 @@ def apply_search_string(metadata: Metadata, text: str) -> None:
         metadata.id_tmdb = None
         metadata.id_imdb = None
         metadata.name = text or None
-        metadata.year = year
+        metadata.year = str(year) if year is not None else None
     elif isinstance(metadata, MetadataEpisode):
         metadata.id_tvdb = None
         metadata.id_tvmaze = None

--- a/mnamer/utils.py
+++ b/mnamer/utils.py
@@ -36,26 +36,42 @@ def clear_cache():
     get_session().cache.clear()
 
 
-def crawl_in(file_paths: list[Path], recurse: bool = False) -> Iterator[Path]:
+def crawl_in(
+    file_paths: list[Path],
+    recurse: bool = False,
+    exclude_paths: set[Path] | None = None,
+    skip_dirs: Iterable[Path] | None = None,
+) -> Iterator[Path]:
     """Yields media file paths amongst or within the paths provided.
 
     Paths are yielded as soon as they are discovered (depth-first via os.walk)
     instead of collecting the full tree first.
+
+    ``exclude_paths`` is consulted live (so callers can add relocated outputs
+    mid-walk). ``skip_dirs`` prevents descending into known destination roots.
     """
     seen: set[Path] = set()
+    exclude_paths = exclude_paths if exclude_paths is not None else set()
+    skip_dirs_abs = {Path(path).absolute() for path in (skip_dirs or [])}
     for file_path in file_paths:
         if not file_path.exists():
             continue
         if file_path.is_file():
             absolute = Path(file_path).absolute()
-            if absolute not in seen:
+            if absolute not in seen and absolute not in exclude_paths:
                 seen.add(absolute)
                 yield absolute
             continue
-        for root, _dirs, files in walk(file_path):
+        for root, dirs, files in walk(file_path):
+            if skip_dirs_abs:
+                dirs[:] = [
+                    name
+                    for name in dirs
+                    if Path(root, name).absolute() not in skip_dirs_abs
+                ]
             for file in files:
                 absolute = Path(root, file).absolute()
-                if absolute in seen:
+                if absolute in seen or absolute in exclude_paths:
                     continue
                 seen.add(absolute)
                 yield absolute

--- a/mnamer/utils.py
+++ b/mnamer/utils.py
@@ -502,6 +502,12 @@ def year_parse(s: str) -> int | None:
         return None
 
 
+def year_from_brackets(s: str) -> int | None:
+    """Return a year only when wrapped in () or [], e.g. (1999) or [1999]."""
+    matches = re.findall(r"[\(\[]((?:19|20)\d{2})[\)\]]", str(s))
+    return int(matches[-1]) if matches else None
+
+
 def year_range_parse(years: str | int | None, tolerance: int = 1) -> tuple[int, int]:
     """Parses a year or dash-delimited year range."""
     regex = r"^((?:19|20)\d{2})?([-,: ]*)?((?:19|20)\d{2})?$"

--- a/mnamer/utils.py
+++ b/mnamer/utils.py
@@ -33,21 +33,31 @@ def clear_cache():
     get_session().cache.clear()
 
 
-def crawl_in(file_paths: list[Path], recurse: bool = False) -> list[Path]:
-    """Looks for files amongst or within paths provided."""
-    found_files = set()
+def crawl_in(file_paths: list[Path], recurse: bool = False) -> Iterator[Path]:
+    """Yields media file paths amongst or within the paths provided.
+
+    Paths are yielded as soon as they are discovered (depth-first via os.walk)
+    instead of collecting the full tree first.
+    """
+    seen: set[Path] = set()
     for file_path in file_paths:
         if not file_path.exists():
             continue
         if file_path.is_file():
-            found_files.add(Path(file_path).absolute())
+            absolute = Path(file_path).absolute()
+            if absolute not in seen:
+                seen.add(absolute)
+                yield absolute
             continue
         for root, _dirs, files in walk(file_path):
             for file in files:
-                found_files.add(Path(root, file).absolute())
+                absolute = Path(root, file).absolute()
+                if absolute in seen:
+                    continue
+                seen.add(absolute)
+                yield absolute
             if not recurse:
                 break
-    return sorted(found_files)
 
 
 def crawl_out(filename: str | Path | PurePath) -> Path | None:
@@ -72,29 +82,29 @@ def filename_replace(filename: str, replacements: dict[str, str]) -> str:
     return base + container
 
 
-def filter_blacklist(paths: list[Path], blacklist: list[str]) -> list[Path]:
-    """Filters (set difference) paths by a collection of regex patterns."""
-    return [
-        path.absolute()
-        for path in paths
-        if not any(
-            re.search(pattern, str(path), re.IGNORECASE)
+def filter_blacklist(
+    paths: Iterable[Path], blacklist: list[str]
+) -> Iterator[Path]:
+    """Filters out paths matching any blacklist regex pattern."""
+    for path in paths:
+        absolute = path.absolute()
+        if any(
+            re.search(pattern, str(absolute), re.IGNORECASE)
             for pattern in blacklist
             if pattern
-        )
-    ]
+        ):
+            continue
+        yield absolute
 
 
 def filter_containers(
-    file_paths: list[Path], valid_containers: list[str]
-) -> list[Path]:
-    """Filters (set intersection) a collection of containers."""
+    file_paths: Iterable[Path], valid_containers: list[str]
+) -> Iterator[Path]:
+    """Keeps paths whose suffix is in valid_containers (or all if empty)."""
     valid_containers = normalize_containers(valid_containers)
-    return [
-        file_path
-        for file_path in file_paths
-        if not valid_containers or file_path.suffix.lower() in valid_containers
-    ]
+    for file_path in file_paths:
+        if not valid_containers or file_path.suffix.lower() in valid_containers:
+            yield file_path
 
 
 def findall(s: str, ss: str) -> Iterator[int]:

--- a/mnamer/utils.py
+++ b/mnamer/utils.py
@@ -101,9 +101,7 @@ def filename_replace(filename: str, replacements: dict[str, str]) -> str:
     return base + container
 
 
-def filter_blacklist(
-    paths: Iterable[Path], blacklist: list[str]
-) -> Iterator[Path]:
+def filter_blacklist(paths: Iterable[Path], blacklist: list[str]) -> Iterator[Path]:
     """Filters out paths matching any blacklist regex pattern."""
     for path in paths:
         absolute = path.absolute()

--- a/mnamer/utils.py
+++ b/mnamer/utils.py
@@ -3,6 +3,7 @@
 import datetime as dt
 import json
 import re
+import threading
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import nullcontext
 from os import walk
@@ -15,6 +16,8 @@ import requests_cache
 from requests.adapters import HTTPAdapter
 
 from mnamer.const import CACHE_PATH, CURRENT_YEAR, SUBTITLE_CONTAINERS
+
+_request_lock = threading.Lock()
 
 
 def clean_dict(
@@ -286,7 +289,8 @@ def request_json(
 
     cache_ctx = session.cache_disabled() if not cache else nullcontext()
     try:
-        with cache_ctx:
+        # Serialize session use — requests-cache SQLite is not thread-safe.
+        with _request_lock, cache_ctx:
             response = session.request(
                 url=url,
                 params=parameters,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -30,6 +30,7 @@ DEFAULT_SETTINGS = {
     "no_guess": False,
     "no_overwrite": False,
     "no_style": False,
+    "skip_correct": False,
     "recurse": False,
     "replace_after": {"&": "and", ";": ",", "@": "at"},
     "replace_before": {},

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -25,7 +25,7 @@ DEFAULT_SETTINGS = {
     "media": None,
     "movie_api": ProviderType.TMDB,
     "movie_directory": None,
-    "movie_format": "{name} ({year}).{extension}",
+    "movie_format": "{name} ({year}) [{resolution}].{extension}",
     "no_cache": False,
     "no_guess": False,
     "no_overwrite": False,

--- a/tests/e2e/test_moving.py
+++ b/tests/e2e/test_moving.py
@@ -38,7 +38,8 @@ def test_batch(e2e_run, setup_test_files):
 
 @pytest.mark.usefixtures("setup_test_dir")
 def test_lower(e2e_run, setup_test_files):
-    setup_test_files("aladdin.2019.avi")
+    # Bare years are kept in the title; use parentheses for a real year field.
+    setup_test_files("aladdin.(2019).avi")
     result = e2e_run("--batch", "--lower", ".")
     assert result.code == 0
     assert "aladdin (2019).avi" in result.out
@@ -46,7 +47,7 @@ def test_lower(e2e_run, setup_test_files):
 
 @pytest.mark.usefixtures("setup_test_dir")
 def test_scene(e2e_run, setup_test_files):
-    setup_test_files("aladdin.2019.avi")
+    setup_test_files("aladdin.(2019).avi")
     result = e2e_run("--batch", "--scene", ".")
     assert result.code == 0
     assert "aladdin.2019.avi" in result.out
@@ -179,7 +180,7 @@ def test_scene_directory(e2e_run, setup_test_files):
 @pytest.mark.omdb
 @pytest.mark.usefixtures("setup_test_dir")
 def test_format_id(e2e_run, setup_test_files):
-    setup_test_files("aladdin.1992.avi")
+    setup_test_files("aladdin.(1992).avi")
     result = e2e_run(
         "--batch",
         "--media=movie",
@@ -221,7 +222,7 @@ def test_format_season0(e2e_run, setup_test_files):
 
 @pytest.mark.usefixtures("setup_test_dir")
 def test_replace_after(e2e_run, setup_test_files):
-    setup_test_files("Pride & Prejudice 2005.ts")
+    setup_test_files("Pride & Prejudice (2005).ts")
     result = e2e_run("--batch", ".")
     assert result.code == 0
     assert "Pride and Prejudice (2005).ts" in result.out

--- a/tests/local/test_media_info.py
+++ b/tests/local/test_media_info.py
@@ -42,15 +42,11 @@ def test_normalize_resolution_token(value, expected):
     assert normalize_resolution_token(value) == expected
 
 
-def test_probe_resolution__missing_file():
-    assert probe_resolution(Path("definitely-missing-video.mkv")) is None
-
-
 def test_probe_resolution__uses_ffprobe(mocker, tmp_path):
     media = tmp_path / "movie.mkv"
     media.write_bytes(b"fake")
     mocker.patch("mnamer.media_info.shutil.which", return_value="ffprobe")
-    mocker.patch(
+    mock_run = mocker.patch(
         "mnamer.media_info.subprocess.run",
         return_value=mocker.Mock(
             returncode=0,
@@ -59,6 +55,22 @@ def test_probe_resolution__uses_ffprobe(mocker, tmp_path):
     )
 
     assert probe_resolution(media) == "1080p"
+    assert mock_run.call_args.kwargs["timeout"] == 5
+
+
+def test_probe_resolution__skips_isfile_check(mocker):
+    mocker.patch("mnamer.media_info.shutil.which", return_value="ffprobe")
+    mock_is_file = mocker.patch.object(Path, "is_file")
+    mocker.patch(
+        "mnamer.media_info.subprocess.run",
+        return_value=mocker.Mock(
+            returncode=0,
+            stdout='{"streams":[{"width":1920,"height":1080}]}',
+        ),
+    )
+
+    assert probe_resolution(Path("/mnt/media/Movies/movie.mkv")) == "1080p"
+    mock_is_file.assert_not_called()
 
 
 def test_probe_resolution__ffprobe_missing(mocker, tmp_path):

--- a/tests/local/test_media_info.py
+++ b/tests/local/test_media_info.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+import pytest
+
+from mnamer.media_info import (
+    normalize_resolution_token,
+    probe_resolution,
+    resolution_label,
+)
+
+pytestmark = pytest.mark.local
+
+
+@pytest.mark.parametrize(
+    ("width", "height", "expected"),
+    (
+        (3840, 2160, "2160p"),
+        (1920, 1080, "1080p"),
+        (1920, 800, "1080p"),
+        (1280, 720, "720p"),
+        (720, 480, "480p"),
+        (None, None, None),
+        (0, 0, None),
+    ),
+)
+def test_resolution_label(width, height, expected):
+    assert resolution_label(width, height) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    (
+        ("1080p", "1080p"),
+        ("720P", "720p"),
+        ("4K", "2160p"),
+        ("uhd", "2160p"),
+        (None, None),
+        ("", None),
+    ),
+)
+def test_normalize_resolution_token(value, expected):
+    assert normalize_resolution_token(value) == expected
+
+
+def test_probe_resolution__missing_file():
+    assert probe_resolution(Path("definitely-missing-video.mkv")) is None
+
+
+def test_probe_resolution__uses_ffprobe(mocker, tmp_path):
+    media = tmp_path / "movie.mkv"
+    media.write_bytes(b"fake")
+    mocker.patch("mnamer.media_info.shutil.which", return_value="ffprobe")
+    mocker.patch(
+        "mnamer.media_info.subprocess.run",
+        return_value=mocker.Mock(
+            returncode=0,
+            stdout='{"streams":[{"width":1920,"height":1080}]}',
+        ),
+    )
+
+    assert probe_resolution(media) == "1080p"
+
+
+def test_probe_resolution__ffprobe_missing(mocker, tmp_path):
+    media = tmp_path / "movie.mkv"
+    media.write_bytes(b"fake")
+    mocker.patch("mnamer.media_info.shutil.which", return_value=None)
+
+    assert probe_resolution(media) is None

--- a/tests/local/test_metadata.py
+++ b/tests/local/test_metadata.py
@@ -33,6 +33,12 @@ def test_metadata__convert_quality(value):
     assert metadata.quality == "test"
 
 
+@pytest.mark.parametrize("value", TEXT_CASES)
+def test_metadata__convert_resolution(value):
+    metadata = Metadata(resolution=value)
+    assert metadata.resolution == "test"
+
+
 def test_metadata__format():
     with pytest.raises(NotImplementedError):
         format(Metadata())

--- a/tests/local/test_prefetch.py
+++ b/tests/local/test_prefetch.py
@@ -114,7 +114,7 @@ def test_process_prepared__uses_prefetched_matches(tmp_path):
     assert target.metadata.name == "Example Movie"
 
 
-def test_process_prepared__skip_correct_when_filename_matches_top_hit(
+def test_process_prepared__skip_correct_when_full_destination_matches(
     tmp_path, mocker
 ):
     media = tmp_path / "Example Movie (1999).mkv"
@@ -134,6 +134,33 @@ def test_process_prepared__skip_correct_when_filename_matches_top_hit(
     assert cli._process_prepared(prepared) is True
     assert cli.success_count == 0
     prompt.assert_not_called()
+
+
+def test_process_prepared__skip_correct_does_not_skip_when_directory_differs(
+    tmp_path, mocker
+):
+    """Same basename in the wrong folder should still be relocated."""
+    media = tmp_path / "incoming" / "Example Movie (1999).mkv"
+    media.parent.mkdir()
+    media.write_bytes(b"x")
+    library = tmp_path / "Movies"
+    settings = SettingStore(
+        targets=[media],
+        media=MediaType.MOVIE,
+        skip_correct=True,
+        batch=True,
+        test=True,
+        movie_directory=library,
+        movie_format="{name} ({year}).{extension}",
+    )
+    target = Target(media, settings)
+    match = MetadataMovie(name="Example Movie", year="1999")
+    prepared = PreparedTarget(target=target, matches=[match])
+
+    cli = Cli(settings)
+    assert cli._process_prepared(prepared) is True
+    assert cli.success_count == 1
+    assert target.destination_for(match) != media.resolve()
 
 
 def test_process_prepared__skip_correct_does_not_skip_when_names_differ(

--- a/tests/local/test_prefetch.py
+++ b/tests/local/test_prefetch.py
@@ -114,9 +114,7 @@ def test_process_prepared__uses_prefetched_matches(tmp_path):
     assert target.metadata.name == "Example Movie"
 
 
-def test_process_prepared__skip_correct_when_full_destination_matches(
-    tmp_path, mocker
-):
+def test_process_prepared__skip_correct_when_full_destination_matches(tmp_path, mocker):
     media = tmp_path / "Example Movie (1999).mkv"
     media.write_bytes(b"x")
     settings = SettingStore(

--- a/tests/local/test_prefetch.py
+++ b/tests/local/test_prefetch.py
@@ -1,0 +1,114 @@
+from threading import Event
+
+import pytest
+
+from mnamer.exceptions import MnamerNetworkException, MnamerNotFoundException
+from mnamer.frontends import Cli
+from mnamer.metadata import MetadataMovie
+from mnamer.prefetch import PreparedTarget, TargetLookahead, prepare_target
+from mnamer.setting_store import SettingStore
+from mnamer.target import Target
+from mnamer.types import MediaType
+
+pytestmark = pytest.mark.local
+
+
+def test_prepare_target__captures_matches(mocker):
+    target = mocker.Mock()
+    matches = [MetadataMovie(name="Example", year="1999")]
+    target.query.return_value = matches
+    target.needs_resolution.return_value = False
+
+    prepared = prepare_target(target)
+
+    assert prepared.target is target
+    assert prepared.matches == matches
+    assert prepared.not_found is False
+    assert prepared.network_error is False
+    target.ensure_resolution.assert_not_called()
+
+
+def test_prepare_target__not_found(mocker):
+    target = mocker.Mock()
+    target.query.side_effect = MnamerNotFoundException
+    target.needs_resolution.return_value = False
+
+    prepared = prepare_target(target)
+
+    assert prepared.matches == []
+    assert prepared.not_found is True
+
+
+def test_prepare_target__network_error(mocker):
+    target = mocker.Mock()
+    target.query.side_effect = MnamerNetworkException
+    target.needs_resolution.return_value = False
+
+    prepared = prepare_target(target)
+
+    assert prepared.matches == []
+    assert prepared.network_error is True
+
+
+def test_prepare_target__probes_resolution_when_needed(mocker):
+    target = mocker.Mock()
+    target.query.return_value = []
+    target.needs_resolution.return_value = True
+
+    prepare_target(target)
+
+    target.ensure_resolution.assert_called_once_with()
+
+
+def test_lookahead__prefetches_next_during_current(mocker):
+    """Second target is queried while the consumer still holds the first."""
+    first = mocker.Mock(name="first")
+    second = mocker.Mock(name="second")
+    first.query.return_value = [MetadataMovie(name="One", year="2001")]
+    second.query.return_value = [MetadataMovie(name="Two", year="2002")]
+    first.needs_resolution.return_value = False
+    second.needs_resolution.return_value = False
+
+    started_second = Event()
+    release_second = Event()
+
+    def second_query():
+        started_second.set()
+        release_second.wait(timeout=2)
+        return [MetadataMovie(name="Two", year="2002")]
+
+    second.query.side_effect = second_query
+
+    with TargetLookahead(iter([first, second])) as lookahead:
+        prepared_first = lookahead.prime()
+        assert prepared_first is not None
+        assert prepared_first.target is first
+        assert started_second.wait(timeout=2)
+        # Prefetch of second is in flight while we still "process" first.
+        assert second.query.call_count == 1
+        release_second.set()
+        prepared_second = lookahead.take()
+        assert prepared_second is not None
+        assert prepared_second.target is second
+        assert prepared_second.matches[0].name == "Two"
+        assert lookahead.take() is None
+
+
+def test_process_prepared__uses_prefetched_matches(tmp_path):
+    media = tmp_path / "Example (1999).mkv"
+    media.write_bytes(b"x")
+    settings = SettingStore(
+        targets=[media],
+        media=MediaType.MOVIE,
+        batch=True,
+        test=True,
+        movie_format="{name} ({year}).{extension}",
+    )
+    target = Target(media, settings)
+    match = MetadataMovie(name="Example Movie", year="1999")
+    prepared = PreparedTarget(target=target, matches=[match])
+
+    cli = Cli(settings)
+    assert cli._process_prepared(prepared) is True
+    assert cli.success_count == 1
+    assert target.metadata.name == "Example Movie"

--- a/tests/local/test_prefetch.py
+++ b/tests/local/test_prefetch.py
@@ -112,3 +112,47 @@ def test_process_prepared__uses_prefetched_matches(tmp_path):
     assert cli._process_prepared(prepared) is True
     assert cli.success_count == 1
     assert target.metadata.name == "Example Movie"
+
+
+def test_process_prepared__skip_correct_when_filename_matches_top_hit(
+    tmp_path, mocker
+):
+    media = tmp_path / "Example Movie (1999).mkv"
+    media.write_bytes(b"x")
+    settings = SettingStore(
+        targets=[media],
+        media=MediaType.MOVIE,
+        skip_correct=True,
+        movie_format="{name} ({year}).{extension}",
+    )
+    target = Target(media, settings)
+    match = MetadataMovie(name="Example Movie", year="1999")
+    prepared = PreparedTarget(target=target, matches=[match])
+    prompt = mocker.patch("mnamer.tty.metadata_prompt")
+
+    cli = Cli(settings)
+    assert cli._process_prepared(prepared) is True
+    assert cli.success_count == 0
+    prompt.assert_not_called()
+
+
+def test_process_prepared__skip_correct_does_not_skip_when_names_differ(
+    tmp_path, mocker
+):
+    media = tmp_path / "wrong name.mkv"
+    media.write_bytes(b"x")
+    settings = SettingStore(
+        targets=[media],
+        media=MediaType.MOVIE,
+        skip_correct=True,
+        batch=True,
+        test=True,
+        movie_format="{name} ({year}).{extension}",
+    )
+    target = Target(media, settings)
+    match = MetadataMovie(name="Example Movie", year="1999")
+    prepared = PreparedTarget(target=target, matches=[match])
+
+    cli = Cli(settings)
+    assert cli._process_prepared(prepared) is True
+    assert cli.success_count == 1

--- a/tests/local/test_providers.py
+++ b/tests/local/test_providers.py
@@ -63,12 +63,13 @@ def test_provider_factory__returns_configured_provider_types():
 
 
 def test_provider_from_settings__uses_api_key_and_cache_flag():
-    settings = SettingStore(api_key_omdb="configured-key", no_cache=True)
+    settings = SettingStore(api_key_omdb="configured-key", no_cache=True, hits=12)
 
     provider = Omdb.from_settings(settings)
 
     assert provider.api_key == "configured-key"
     assert provider.cache is False
+    assert provider.hits == 12
 
 
 def test_tvdb_from_settings__logs_in_when_cache_is_disabled(mocker):
@@ -79,6 +80,7 @@ def test_tvdb_from_settings__logs_in_when_cache_is_disabled(mocker):
 
     assert provider.cache is False
     assert provider.token == "token"
+    assert provider.hits == 5
     mock_login.assert_called_once_with("configured-key")
 
 
@@ -282,6 +284,30 @@ def test_tvdb_search__series_tries_candidate_ids(mocker):
     assert mock_search_id.call_count == 2
 
 
+def test_tvdb_search__series_respects_hits(mocker):
+    provider = Tvdb("key", hits=2)
+    provider.token = "token"
+    mocker.patch(
+        "mnamer.providers.tvdb_search_series",
+        return_value={"data": [{"id": 1}, {"id": 2}, {"id": 3}]},
+    )
+    mock_search_id = mocker.patch.object(
+        provider,
+        "_search_id",
+        side_effect=[
+            MnamerNotFoundException,
+            [MetadataEpisode(id_tvdb="2", series="Example Series", season=1)],
+        ],
+    )
+
+    results = list(provider.search(MetadataEpisode(series="Example Series")))
+
+    assert [result.id_tvdb for result in results] == ["2"]
+    assert mock_search_id.call_count == 2
+    mock_search_id.assert_any_call("1", None, None, None)
+    mock_search_id.assert_any_call("2", None, None, None)
+
+
 def test_tvdb_search__date_filters_id_results(mocker):
     provider = Tvdb("key")
     provider.token = "token"
@@ -357,7 +383,7 @@ def test_tvmaze_search__id_filters_episode_list(mocker):
     assert [result.title for result in results] == ["Episode Two"]
 
 
-def test_tvmaze_search__series_season_episode_tries_first_three(mocker):
+def test_tvmaze_search__series_season_episode_respects_hits(mocker):
     shows = [
         {"show": {**TVMAZE_SHOW, "id": 201}},
         {"show": TVMAZE_SHOW},
@@ -375,11 +401,41 @@ def test_tvmaze_search__series_season_episode_tries_first_three(mocker):
     )
 
     results = list(
-        TvMaze().search(MetadataEpisode(series="Example Series", season=1, episode=2))
+        TvMaze(hits=3).search(
+            MetadataEpisode(series="Example Series", season=1, episode=2)
+        )
     )
 
     assert [result.id_tvmaze for result in results] == ["200"]
     assert mock_episode.call_count == 3
+
+
+def test_tvmaze_search__series_season_episode_honours_higher_hits(mocker):
+    shows = [
+        {"show": {**TVMAZE_SHOW, "id": 201}},
+        {"show": {**TVMAZE_SHOW, "id": 202}},
+        {"show": {**TVMAZE_SHOW, "id": 203}},
+        {"show": TVMAZE_SHOW},
+    ]
+    mocker.patch("mnamer.providers.tvmaze_show_search", return_value=shows)
+    mock_episode = mocker.patch(
+        "mnamer.providers.tvmaze_episode_by_number",
+        side_effect=[
+            MnamerNotFoundException,
+            MnamerNotFoundException,
+            MnamerNotFoundException,
+            TVMAZE_EPISODE,
+        ],
+    )
+
+    results = list(
+        TvMaze(hits=4).search(
+            MetadataEpisode(series="Example Series", season=1, episode=2)
+        )
+    )
+
+    assert [result.id_tvmaze for result in results] == ["200"]
+    assert mock_episode.call_count == 4
 
 
 def test_tvmaze_search__series_filters_episode_list(mocker):

--- a/tests/local/test_target.py
+++ b/tests/local/test_target.py
@@ -28,6 +28,28 @@ def test_parse__quality():
     assert target.metadata.quality == "1080p dolby digital"
 
 
+def test_parse__resolution__from_filename():
+    file_path = Path("ninja.turtles.s01e04.1080p.ac3.rargb.sample.mkv")
+    target = Target(file_path, SettingStore())
+    assert target.metadata.resolution == "1080p"
+
+
+def test_parse__resolution__from_file_probe(mocker, tmp_path):
+    media = tmp_path / "2001 A Space Odyssey.mkv"
+    media.write_bytes(b"fake")
+    mocker.patch("mnamer.target.probe_resolution", return_value="1080p")
+    target = Target(media, SettingStore(media=MediaType.MOVIE))
+    assert target.metadata.resolution == "1080p"
+
+
+def test_destination__includes_resolution_from_probe(mocker, tmp_path):
+    media = tmp_path / "2001 A Space Odyssey (1968).mkv"
+    media.write_bytes(b"fake")
+    mocker.patch("mnamer.target.probe_resolution", return_value="1080p")
+    target = Target(media, SettingStore(media=MediaType.MOVIE, batch=True))
+    assert target.destination.name == "2001 a Space Odyssey (1968) [1080p].mkv"
+
+
 def test_parse__group():
     file_path = Path("ninja.turtles.s01e04.1080p.ac3.rargb.sample.mkv")
     target = Target(file_path, SettingStore())

--- a/tests/local/test_target.py
+++ b/tests/local/test_target.py
@@ -34,20 +34,47 @@ def test_parse__resolution__from_filename():
     assert target.metadata.resolution == "1080p"
 
 
-def test_parse__resolution__from_file_probe(mocker, tmp_path):
+def test_parse__resolution__does_not_probe_during_init(mocker):
+    mock_probe = mocker.patch("mnamer.target.probe_resolution", return_value="2160p")
+    target = Target(Path("2001 A Space Odyssey.mkv"), SettingStore(media=MediaType.MOVIE))
+    assert target.metadata.resolution is None
+    mock_probe.assert_not_called()
+
+
+def test_ensure_resolution__probes_lazily_when_needed(mocker, tmp_path):
+    media = tmp_path / "2001 A Space Odyssey.mkv"
+    media.write_bytes(b"fake")
+    mock_probe = mocker.patch("mnamer.target.probe_resolution", return_value="1080p")
+    target = Target(media, SettingStore(media=MediaType.MOVIE))
+    assert target.metadata.resolution is None
+    mock_probe.assert_not_called()
+
+    _ = target.destination
+    assert target.metadata.resolution == "1080p"
+    mock_probe.assert_called_once_with(media)
+
+
+def test_ensure_resolution__skips_probe_when_filename_has_resolution(mocker):
+    mock_probe = mocker.patch("mnamer.target.probe_resolution", return_value="2160p")
+    target = Target(
+        Path("movie.1080p.mkv"),
+        SettingStore(media=MediaType.MOVIE),
+    )
+    _ = target.destination
+    assert target.metadata.resolution == "1080p"
+    mock_probe.assert_not_called()
+
+
+def test_preview_filename__uses_match_and_format(mocker, tmp_path):
     media = tmp_path / "2001 A Space Odyssey.mkv"
     media.write_bytes(b"fake")
     mocker.patch("mnamer.target.probe_resolution", return_value="1080p")
-    target = Target(media, SettingStore(media=MediaType.MOVIE))
-    assert target.metadata.resolution == "1080p"
-
-
-def test_destination__includes_resolution_from_probe(mocker, tmp_path):
-    media = tmp_path / "2001 A Space Odyssey (1968).mkv"
-    media.write_bytes(b"fake")
-    mocker.patch("mnamer.target.probe_resolution", return_value="1080p")
     target = Target(media, SettingStore(media=MediaType.MOVIE, batch=True))
-    assert target.destination.name == "2001 a Space Odyssey (1968) [1080p].mkv"
+    match = MetadataMovie(name="2001: A Space Odyssey", year="1968")
+    assert target.preview_filename(match) == "2001 a Space Odyssey (1968) [1080p].mkv"
+    # Original parse metadata should be restored
+    assert target.metadata.name == "2001 a Space Odyssey"
+    assert target.metadata.year is None
 
 
 def test_parse__group():

--- a/tests/local/test_target.py
+++ b/tests/local/test_target.py
@@ -20,9 +20,7 @@ def test_parse__media__movie():
 
 def test_parse__movie_keeps_number_in_title():
     """MediaType enum must be passed to guessit as its string value."""
-    target = Target(
-        Path("The 400 Blows.mkv"), SettingStore(media=MediaType.MOVIE)
-    )
+    target = Target(Path("The 400 Blows.mkv"), SettingStore(media=MediaType.MOVIE))
     assert isinstance(target.metadata, MetadataMovie)
     assert target.metadata.name == "The 400 Blows"
 
@@ -46,7 +44,9 @@ def test_parse__resolution__from_filename():
 
 def test_parse__resolution__does_not_probe_during_init(mocker):
     mock_probe = mocker.patch("mnamer.target.probe_resolution", return_value="2160p")
-    target = Target(Path("2001 A Space Odyssey.mkv"), SettingStore(media=MediaType.MOVIE))
+    target = Target(
+        Path("2001 A Space Odyssey.mkv"), SettingStore(media=MediaType.MOVIE)
+    )
     assert target.metadata.resolution is None
     mock_probe.assert_not_called()
 
@@ -205,9 +205,7 @@ def test_ambiguous_subtitle_language():
 
 
 def test_parse__subtitle_language_code_in_filename():
-    target = Target(
-        Path("Spirited Away.en.srt"), SettingStore(media=MediaType.MOVIE)
-    )
+    target = Target(Path("Spirited Away.en.srt"), SettingStore(media=MediaType.MOVIE))
     assert target.metadata.container == ".srt"
     assert target.metadata.language_sub is not None
     assert target.metadata.language_sub.a2 == "en"

--- a/tests/local/test_target.py
+++ b/tests/local/test_target.py
@@ -18,6 +18,15 @@ def test_parse__media__movie():
     assert target.metadata.to_media_type() is MediaType.MOVIE
 
 
+def test_parse__movie_keeps_number_in_title():
+    """MediaType enum must be passed to guessit as its string value."""
+    target = Target(
+        Path("The 400 Blows.mkv"), SettingStore(media=MediaType.MOVIE)
+    )
+    assert isinstance(target.metadata, MetadataMovie)
+    assert target.metadata.name == "The 400 Blows"
+
+
 def test_parse__media__episode():
     target = Target(Path("ninja turtles s01e01.mkv"), SettingStore())
     assert target.metadata.to_media_type() is MediaType.EPISODE

--- a/tests/local/test_target.py
+++ b/tests/local/test_target.py
@@ -8,6 +8,7 @@ from mnamer.metadata import MetadataEpisode, MetadataMovie
 from mnamer.setting_store import SettingStore
 from mnamer.target import Target
 from mnamer.types import MediaType
+from mnamer.utils import is_subtitle
 
 pytestmark = pytest.mark.local
 
@@ -190,6 +191,32 @@ def test_ambiguous_subtitle_language():
         Path("Subs/Nancy.Drew.S01E01.WEBRip.x264-ION10.srt"), SettingStore()
     )
     assert target.metadata.language is None
+    assert target.metadata.language_sub is None
+    assert target.metadata.container == ".srt"
+
+
+def test_parse__subtitle_language_code_in_filename():
+    target = Target(
+        Path("Spirited Away.en.srt"), SettingStore(media=MediaType.MOVIE)
+    )
+    assert target.metadata.container == ".srt"
+    assert target.metadata.language_sub is not None
+    assert target.metadata.language_sub.a2 == "en"
+    assert target.metadata.name == "Spirited Away"
+    assert target.metadata.extension == ".en.srt"
+    assert is_subtitle(target.metadata.container)
+
+
+def test_parse__subtitle_language_stem_uses_parent_title():
+    target = Target(
+        Path("Spirited Away (2001)/Eng.srt"), SettingStore(media=MediaType.MOVIE)
+    )
+    assert target.metadata.container == ".srt"
+    assert target.metadata.language_sub is not None
+    assert target.metadata.language_sub.a2 == "en"
+    assert target.metadata.name == "Spirited Away"
+    assert target.metadata.year == 2001
+    assert target.metadata.extension == ".en.srt"
 
 
 def test_destination__simple():

--- a/tests/local/test_target.py
+++ b/tests/local/test_target.py
@@ -69,14 +69,45 @@ def test_parse__series():
 
 
 def test_parse__year():
-    file_path = Path("the.goonies.1985")
+    file_path = Path("the.goonies.(1985).mkv")
     target = Target(file_path, SettingStore())
     assert isinstance(target.metadata, MetadataMovie)
     assert target.metadata.year == 1985
 
 
+def test_parse__year__square_brackets():
+    file_path = Path("the.goonies.[1985].mkv")
+    target = Target(file_path, SettingStore())
+    assert isinstance(target.metadata, MetadataMovie)
+    assert target.metadata.year == 1985
+
+
+def test_parse__year__bare_number_kept_in_title():
+    file_path = Path("2001 A Space Odyssey.mkv")
+    target = Target(file_path, SettingStore(media=MediaType.MOVIE))
+    assert isinstance(target.metadata, MetadataMovie)
+    assert target.metadata.name == "2001 a Space Odyssey"
+    assert target.metadata.year is None
+
+
+def test_parse__year__title_year_with_bracketed_release():
+    file_path = Path("2001 A Space Odyssey (1968).mkv")
+    target = Target(file_path, SettingStore(media=MediaType.MOVIE))
+    assert isinstance(target.metadata, MetadataMovie)
+    assert target.metadata.name == "2001 a Space Odyssey"
+    assert target.metadata.year == 1968
+
+
+def test_parse__year__bare_trailing_year_ignored():
+    file_path = Path("the.goonies.1985.mkv")
+    target = Target(file_path, SettingStore())
+    assert isinstance(target.metadata, MetadataMovie)
+    assert target.metadata.year is None
+    assert target.metadata.name == "The Goonies 1985"
+
+
 def testparse__name():
-    file_path = Path("the.goonies.1985")
+    file_path = Path("the.goonies.(1985).mkv")
     target = Target(file_path, SettingStore())
     assert isinstance(target.metadata, MetadataMovie)
     assert target.metadata.name == "The Goonies"
@@ -246,8 +277,31 @@ def test_destination__same_directory_matches_source(tmp_path, monkeypatch):
     assert target.destination == target.source
 
 
-def test_query():
-    pass  # TODO
+def test_query(mocker):
+    Target.reset_providers()
+    settings = SettingStore(hits=2)
+    target = Target(Path("ninja turtles (1990).mkv"), settings)
+    matches = [
+        MetadataMovie(name="Teenage Mutant Ninja Turtles", year="1990"),
+        MetadataMovie(name="Teenage Mutant Ninja Turtles", year="1990"),  # duplicate
+        MetadataMovie(name="Ninja Turtles", year="2007"),
+        MetadataMovie(name="TMNT", year="2014"),
+    ]
+    mocker.patch.object(target._provider, "search", return_value=iter(matches))
+
+    results = target.query()
+
+    assert len(results) == 2
+    assert results[0].name == "Teenage Mutant Ninja Turtles"
+    assert results[1].name == "Ninja Turtles"
+
+
+def test_query__empty(mocker):
+    Target.reset_providers()
+    target = Target(Path("ninja turtles (1990).mkv"), SettingStore(hits=5))
+    mocker.patch.object(target._provider, "search", return_value=iter([]))
+
+    assert target.query() == []
 
 
 def test_relocate():

--- a/tests/local/test_tty.py
+++ b/tests/local/test_tty.py
@@ -185,3 +185,25 @@ def test_iter_paths_streams_as_discovered(tmp_path):
             # First file is available before the full tree is necessarily finished.
             assert yielded[0] in {"first.mkv", "second.mkv"}
     assert set(yielded) == {"first.mkv", "second.mkv"}
+
+
+def test_iter_paths__skips_concrete_movie_directory(tmp_path):
+    from mnamer.setting_store import SettingStore
+    from mnamer.target import Target
+    from mnamer.types import MediaType
+
+    library = tmp_path / "Movies"
+    library.mkdir()
+    keep = tmp_path / "keep.mkv"
+    skip = library / "skip.mkv"
+    keep.write_bytes(b"x")
+    skip.write_bytes(b"x")
+    settings = SettingStore(
+        targets=[tmp_path],
+        recurse=True,
+        media=MediaType.MOVIE,
+        mask=[".mkv"],
+        movie_directory=library,
+    )
+    yielded = [target.source.name for target in Target.iter_paths(settings)]
+    assert yielded == ["keep.mkv"]

--- a/tests/local/test_tty.py
+++ b/tests/local/test_tty.py
@@ -65,6 +65,75 @@ def test_abort_helpers__no_style():
     assert helpers[1]._bracketed is True
 
 
+def test_edit_search_helper():
+    tty.no_style = False
+    helper = tty._edit_search_helper()
+    assert helper.label == "edit search"
+    assert isinstance(helper.value, tty.EditSearchAction)
+    assert helper.mnemonic == "e"
+
+
+def test_search_string_for_movie_and_episode():
+    from mnamer.metadata import MetadataEpisode, MetadataMovie
+
+    assert tty.search_string_for(MetadataMovie(name="The Matrix")) == "The Matrix"
+    assert tty.search_string_for(MetadataEpisode(series="Dark")) == "Dark"
+    assert tty.search_string_for(MetadataMovie()) == ""
+
+
+def test_apply_search_string__movie_clears_ids_and_parses_year():
+    from mnamer.metadata import MetadataMovie
+
+    metadata = MetadataMovie(
+        name="Wrong",
+        year="2001",
+        id_tmdb="1",
+        id_imdb="tt1",
+    )
+    tty.apply_search_string(metadata, "2001 A Space Odyssey (1968)")
+    assert metadata.name == "2001 a Space Odyssey"
+    assert metadata.year == 1968
+    assert metadata.id_tmdb is None
+    assert metadata.id_imdb is None
+
+
+def test_apply_search_string__episode_clears_ids():
+    from mnamer.metadata import MetadataEpisode
+
+    metadata = MetadataEpisode(series="Wrong", id_tvdb="1", id_tvmaze="2")
+    tty.apply_search_string(metadata, "Better Call Saul")
+    assert metadata.series == "Better Call Saul"
+    assert metadata.id_tvdb is None
+    assert metadata.id_tvmaze is None
+
+
+def test_prompt_with_prefill__fallback_keeps_default_on_empty(mocker):
+    mocker.patch.dict("sys.modules", {"readline": None})
+    mocker.patch("builtins.input", return_value="")
+    assert tty.prompt_with_prefill("search: ", "The Matrix") == "The Matrix"
+
+
+def test_prompt_with_prefill__fallback_uses_typed_value(mocker):
+    mocker.patch.dict("sys.modules", {"readline": None})
+    mocker.patch("builtins.input", return_value="Inception")
+    assert tty.prompt_with_prefill("search: ", "The Matrix") == "Inception"
+
+
+def test_prompt_with_prefill__readline_inserts_default(mocker):
+    import sys
+    import types
+
+    readline = types.SimpleNamespace(
+        insert_text=mocker.Mock(),
+        redisplay=mocker.Mock(),
+        set_pre_input_hook=mocker.Mock(),
+    )
+    mocker.patch.dict(sys.modules, {"readline": readline})
+    mocker.patch("builtins.input", return_value="edited")
+    assert tty.prompt_with_prefill("search: ", "default") == "edited"
+    readline.set_pre_input_hook.assert_called()
+
+
 def test_match_choice_helpers_two_columns(tmp_path, mocker):
     from mnamer.metadata import MetadataMovie
     from mnamer.setting_store import SettingStore

--- a/tests/local/test_tty.py
+++ b/tests/local/test_tty.py
@@ -63,3 +63,56 @@ def test_abort_helpers__no_style():
     assert helpers[1].label == "quit"
     assert isinstance(helpers[1].value, MnamerAbortException)
     assert helpers[1]._bracketed is True
+
+
+def test_match_choice_helpers_two_columns(tmp_path, mocker):
+    from mnamer.metadata import MetadataMovie
+    from mnamer.setting_store import SettingStore
+    from mnamer.target import Target
+    from mnamer.types import MediaType
+
+    media = tmp_path / "movie.mkv"
+    media.write_bytes(b"fake")
+    mocker.patch("mnamer.target.probe_resolution", return_value="1080p")
+    target = Target(media, SettingStore(media=MediaType.MOVIE))
+    matches = [
+        MetadataMovie(name="Short", year="1999"),
+        MetadataMovie(name="A Much Longer Title", year="2001"),
+    ]
+    choices = tty._match_choice_helpers(matches, target)
+    assert len(choices) == 2
+    assert choices[0].value is matches[0]
+    assert choices[0].label is not None
+    assert "Short" in choices[0].label
+    assert "Short (1999) [1080p].mkv" in choices[0].label
+    assert "A Much Longer Title (2001) [1080p].mkv" in choices[1].label
+    # Columns are padded so previews share an alignment offset.
+    assert choices[0].label.index("Short (1999)") == choices[1].label.index(
+        "A Much Longer Title (2001)"
+    )
+
+
+def test_iter_paths_streams_as_discovered(tmp_path):
+    from mnamer.setting_store import SettingStore
+    from mnamer.target import Target
+    from mnamer.types import MediaType
+
+    nested = tmp_path / "a" / "b"
+    nested.mkdir(parents=True)
+    first = tmp_path / "a" / "first.mkv"
+    second = nested / "second.mkv"
+    first.write_bytes(b"x")
+    second.write_bytes(b"x")
+    settings = SettingStore(
+        targets=[tmp_path],
+        recurse=True,
+        media=MediaType.MOVIE,
+        mask=[".mkv"],
+    )
+    yielded = []
+    for target in Target.iter_paths(settings):
+        yielded.append(target.source.name)
+        if len(yielded) == 1:
+            # First file is available before the full tree is necessarily finished.
+            assert yielded[0] in {"first.mkv", "second.mkv"}
+    assert set(yielded) == {"first.mkv", "second.mkv"}

--- a/tests/local/test_utils.py
+++ b/tests/local/test_utils.py
@@ -27,6 +27,7 @@ from mnamer.utils import (
     str_scenify,
     str_title_case,
     year_parse,
+    year_from_brackets,
     year_range_parse,
 )
 from tests import JUNK_TEXT, MockRequestResponse
@@ -830,6 +831,34 @@ def test_year_parse__valid():
 @pytest.mark.parametrize("s", ("1", "5000", "", " hello", "-", ","))
 def test_year_parse__unexpected(s: str):
     assert year_parse(s) is None
+
+
+@pytest.mark.parametrize(
+    ("s", "expected"),
+    (
+        ("The Matrix (1999).mkv", 1999),
+        ("The Matrix [1999].mkv", 1999),
+        ("2001 A Space Odyssey (1968).mkv", 1968),
+        ("Movie (USA) (2020).mkv", 2020),
+        ("Movie [Bluray] [2019].mkv", 2019),
+    ),
+)
+def test_year_from_brackets__valid(s: str, expected: int):
+    assert year_from_brackets(s) == expected
+
+
+@pytest.mark.parametrize(
+    "s",
+    (
+        "2001 A Space Odyssey.mkv",
+        "The Matrix 1999.mkv",
+        "The Matrix.1999.1080p.mkv",
+        "Movie (1080).mkv",
+        "",
+    ),
+)
+def test_year_from_brackets__absent(s: str):
+    assert year_from_brackets(s) is None
 
 
 @pytest.mark.parametrize("s", ("1950", " 1950", "  1950 "))

--- a/tests/local/test_utils.py
+++ b/tests/local/test_utils.py
@@ -26,8 +26,8 @@ from mnamer.utils import (
     str_sanitize,
     str_scenify,
     str_title_case,
-    year_parse,
     year_from_brackets,
+    year_parse,
     year_range_parse,
 )
 from tests import JUNK_TEXT, MockRequestResponse
@@ -223,9 +223,7 @@ def test_crawl_in__skips_configured_destination_dirs(tmp_path):
     keep.write_bytes(b"x")
     skip.write_bytes(b"x")
 
-    actual = list(
-        crawl_in([tmp_path], recurse=True, skip_dirs=[library])
-    )
+    actual = list(crawl_in([tmp_path], recurse=True, skip_dirs=[library]))
     assert keep.absolute() in actual
     assert skip.absolute() not in actual
 

--- a/tests/local/test_utils.py
+++ b/tests/local/test_utils.py
@@ -160,7 +160,7 @@ def test_parse_date__dash():
 @pytest.mark.usefixtures("setup_test_dir")
 def test_dir_crawl_in__files__none():
     expected = []
-    actual = crawl_in([Path(".", JUNK_TEXT)])
+    actual = list(crawl_in([Path(".", JUNK_TEXT)]))
     assert actual == expected
 
 
@@ -187,7 +187,7 @@ def test_dir_crawl_in__files__flat(setup_test_files):
         "scan001.tiff",
         "temp.zip",
     )
-    actual = crawl_in([Path.cwd()])
+    actual = list(crawl_in([Path.cwd()]))
     assert set(actual) == set(expected)
 
 
@@ -195,7 +195,7 @@ def test_dir_crawl_in__files__flat(setup_test_files):
 def test_dir_crawl_in__dirs__multiple(setup_test_files):
     setup_test_files(*TEST_FILES.keys())
     file_paths = [Path(filename) for filename in ("Desktop", "Downloads", "Images")]
-    actual = crawl_in(file_paths)
+    actual = list(crawl_in(file_paths))
     expected = paths_for(
         "Downloads/Return of the Jedi 1080p.mkv",
         "Downloads/archer.2009.s10e07.webrip.x264-lucidtv.mkv",
@@ -208,7 +208,7 @@ def test_dir_crawl_in__dirs__multiple(setup_test_files):
 @pytest.mark.usefixtures("setup_test_dir")
 def test_dir_crawl_in__dirs__recurse(setup_test_files):
     setup_test_files(*TEST_FILES.keys())
-    actual = crawl_in([Path.cwd()], recurse=True)
+    actual = list(crawl_in([Path.cwd()], recurse=True))
     expected = paths_for(*TEST_FILES.keys())
     assert set(actual) == set(expected)
 
@@ -306,7 +306,7 @@ def test_str_scenify__utf8_to_ascii():
 @pytest.mark.parametrize("sequence", ([], set(), ()))
 def test_filter_blacklist__filter_none(sequence):
     expected = FILTER_FILENAMES
-    actual = filter_blacklist(FILTER_FILENAMES, sequence)
+    actual = list(filter_blacklist(FILTER_FILENAMES, sequence))
     assert actual == expected
 
 
@@ -314,7 +314,7 @@ def test_filter_blacklist__filter_multiple_paths_single_pattern():
     expected = paths_except_for(
         "Images/Photos/DCM0001.jpg", "Images/Photos/DCM0002.jpg"
     )
-    actual = filter_blacklist(FILTER_FILENAMES, ["dcm"])
+    actual = list(filter_blacklist(FILTER_FILENAMES, ["dcm"]))
     assert actual == expected
 
 
@@ -324,7 +324,7 @@ def test_filter_blacklist__filter_multiple_paths_multiple_patterns():
         "Downloads/the.goonies.1985.sample.mp4",
         "Sample/the mandalorian s01x02.mp4",
     )
-    actual = filter_blacklist(FILTER_FILENAMES, ["temp", "sample"])
+    actual = list(filter_blacklist(FILTER_FILENAMES, ["temp", "sample"]))
     assert actual == expected
 
 
@@ -332,7 +332,7 @@ def test_filter_blacklist__filter_single_path_single_pattern():
     expected = paths_except_for(
         "Images/sample.file.mp4", "Sample/the mandalorian s01x02.mp4"
     )
-    actual = filter_blacklist(expected, ["sample"])
+    actual = list(filter_blacklist(expected, ["sample"]))
     assert actual == expected
 
 
@@ -340,7 +340,7 @@ def test_filter_blacklist__filter_single_path_multiple_patterns():
     expected = paths_except_for(
         "Images/sample.file.mp4", "Sample/the mandalorian s01x02.mp4"
     )
-    actual = filter_blacklist(expected, ["files", "sample"])
+    actual = list(filter_blacklist(expected, ["files", "sample"]))
     assert expected == actual
 
 
@@ -361,13 +361,13 @@ def test_filter_blacklist__regex():
         "made up movie.mp4",
         "made up show s01e10.mkv",
     )
-    actual = filter_blacklist(FILTER_FILENAMES, [pattern])
+    actual = list(filter_blacklist(FILTER_FILENAMES, [pattern]))
     assert actual == expected
 
 
 def test_filter_containers__filter_none():
     expected = FILTER_FILENAMES
-    actual = filter_containers(FILTER_FILENAMES, [])
+    actual = list(filter_containers(FILTER_FILENAMES, []))
     assert expected == actual
 
 
@@ -376,7 +376,7 @@ def test_filter_containers__filter_multiple_paths_single_pattern(
     containers: list[str],
 ):
     expected = paths_for("Images/Photos/DCM0001.jpg", "Images/Photos/DCM0002.jpg")
-    actual = filter_containers(FILTER_FILENAMES, containers)
+    actual = list(filter_containers(FILTER_FILENAMES, containers))
     assert expected == actual
 
 
@@ -394,7 +394,7 @@ def test_filter_containers__filter_multiple_paths_multi_pattern(
         "s.w.a.t.2017.s02e01.mkv",
         "temp.zip",
     )
-    actual = filter_containers(FILTER_FILENAMES, containers)
+    actual = list(filter_containers(FILTER_FILENAMES, containers))
     assert expected == actual
 
 
@@ -404,7 +404,7 @@ def test_filter_containers__filter_single_path_multi_pattern(
 ):
     filepaths = paths_for("Images/Skiing Trip.mp4")
     expected = filepaths
-    actual = filter_containers(filepaths, containers)
+    actual = list(filter_containers(filepaths, containers))
     assert expected == actual
 
 

--- a/tests/local/test_utils.py
+++ b/tests/local/test_utils.py
@@ -213,6 +213,41 @@ def test_dir_crawl_in__dirs__recurse(setup_test_files):
     assert set(actual) == set(expected)
 
 
+def test_crawl_in__skips_configured_destination_dirs(tmp_path):
+    incoming = tmp_path / "incoming"
+    library = tmp_path / "Movies"
+    incoming.mkdir()
+    library.mkdir()
+    keep = incoming / "keep.mkv"
+    skip = library / "already.mkv"
+    keep.write_bytes(b"x")
+    skip.write_bytes(b"x")
+
+    actual = list(
+        crawl_in([tmp_path], recurse=True, skip_dirs=[library])
+    )
+    assert keep.absolute() in actual
+    assert skip.absolute() not in actual
+
+
+def test_crawl_in__exclude_paths_consulted_live(tmp_path):
+    first = tmp_path / "first.mkv"
+    second = tmp_path / "nested" / "second.mkv"
+    second.parent.mkdir()
+    first.write_bytes(b"x")
+    second.write_bytes(b"x")
+    exclude: set[Path] = set()
+
+    yielded: list[Path] = []
+    for path in crawl_in([tmp_path], recurse=True, exclude_paths=exclude):
+        yielded.append(path)
+        if path == first.absolute():
+            exclude.add(second.absolute())
+
+    assert first.absolute() in yielded
+    assert second.absolute() not in yielded
+
+
 @pytest.mark.usefixtures("setup_test_dir")
 def test_test_crawl_out__walking(setup_test_files):
     setup_test_files(*TEST_FILES.keys())


### PR DESCRIPTION
## Summary

This PR bundles a set of usability and correctness improvements developed while renaming a large movie library. It focuses on making interactive matching faster and more controllable, fixing several filename/subtitle parsing bugs, and making hit limits actually take effect in provider searches.

### Match result limits (`--hits`)
- **`--hits` now drives provider search depth**, not only the final prompt truncation.
- TVDb and TvMaze previously hard-capped series candidates at 5 and 3 respectively, so raising `--hits` often did nothing.
- `Target.query()` now counts **unique** results when applying the hit limit.

### Year parsing
- Bare numbers are **no longer treated as release years**.
- Only years in `()` or `[]` (e.g. `(1968)`, `[1999]`) are used as the year.
- Fixes false searches like `2001 A Space Odyssey` → title `A Space Odyssey`, year `2001`.
- Bare years are folded back into the title for searching (e.g. `2001 A Space Odyssey`).

### Resolution from the file (`{resolution}`)
- New `{resolution}` template field (e.g. `1080p`, `2160p`).
- Detected via **ffprobe** when needed, with filename `screen_size` as a fallback.
- Default movie format is now `{name} ({year}) [{resolution}].{extension}` (empty `[]` is stripped when resolution is unknown).
- Probing is **lazy**: not run during bulk target construction (important on large/network libraries).

### Streaming discovery + prefetch
- Files are **yielded and processed as discovered** instead of waiting for a full recursive walk + Target list.
- While the user is choosing a match, the **next file is prepared in the background** (discover + provider query), with locking around the shared requests-cache session and provider registry.

### Interactive UX
- Match menu shows a **second column preview** of the destination filename for each option.
- New menu action **`edit search`**: edit the current search string (prefilled), clear provider IDs, re-query, and show results again.
- New flag **`--skip-correct`**: skip prompting/renaming when the current filename already matches the top hit's destination filename.

### Bug fixes
- **Subtitles** like `Spirited Away.en.srt`: keep `.srt` container, set `language_sub`, and stop leaving a dangling dot / broken extension.
- **`--media movie` + numbered titles** like `The 400 Blows`: pass `"movie"` / `"episode"` strings into guessit. Passing the `MediaType` enum caused guessit to ignore the hint and split titles on numbers (`400` → season/episode, title → `The`).

### Tests
- Local unit coverage added/updated for providers, target parsing, media info, prefetch, tty helpers, and settings defaults.

## Test plan
- [ ] `uv run pytest tests/local -q`
- [ ] Interactive: `mnamer --media movie --hits 10 "The 400 Blows.mkv"` searches for the full title
- [ ] Interactive: `mnamer --media movie "2001 A Space Odyssey.mkv"` searches `2001 A Space Odyssey` (not year-filtered NASA docs)
- [ ] Confirm match list shows title + destination filename columns
- [ ] Use **edit search**, change the query, confirm new results appear
- [ ] `--skip-correct` skips already-correctly-named files
- [ ] `Movie.en.srt` announces as a subtitle and renames to `...en.srt`
- [ ] Recursive run over a large tree starts processing before the walk finishes
- [ ] While sitting on a prompt, the next file's provider query is already in flight / ready
- [ ] `{resolution}` / default movie format produces `[1080p]` when ffprobe (or filename) provides a size
